### PR TITLE
Wrapper class

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ std::cout << "Gradient of small: " << small.get_grad() << "\n";
 ## Usage
 
 ## Design Choices
+- result_shape in backward function
 - Make no difference when broadcasting
 - Tensors having unique IDs
 - using make_shared(*this) copies data instead of creating a ref

--- a/demo/tutorial.cpp
+++ b/demo/tutorial.cpp
@@ -2,86 +2,126 @@
 This tutorial demonstrates how to use the autograd engine step by step.
 We will explore scalar operations, multi-dimensional tensors, and backpropagation.
 */
-
+#include <torch/torch.h>
 #include "../grad/cppgrad.h"
 #include <iostream>
 
 int main() {
-    std::cout << "=== Scalar Operations ===\n";
-    // Step 1: Simple scalar operations
-    // Define two scalar tensors with values 3.0 and 4.0
-    Tensor a = Tensor({3.0}, true);
-    Tensor b = Tensor({4.0}, true);
+    // std::cout << "=== Scalar Operations ===\n";
+    // // Step 1: Simple scalar operations
+    // // Define two scalar tensors with values 3.0 and 4.0
+    // Tensor a = Tensor({3.0}, true);
+    // Tensor b = Tensor({4.0}, true);
     
-    // Perform multiplication and addition: c = a * b + 2
-    Tensor c = a * b + 2.0;
-    std::cout << "c = a * b + 2 -> " << c << "\n";
+    // // Perform multiplication and addition: c = a * b + 2
+    // Tensor c = a * b + 2.0;
+    // std::cout << "c = a * b + 2 -> " << c << "\n";
 
-    std::cout << "=== Creating Multi-Dimensional Tensors ===\n";
-    // Step 2: Creating multi-dimensional tensors
-    // Define a 2x3 tensor with explicit values
-    Tensor d = Tensor({1,2,3,4,5,6}, {2, 3}, true);
+    // std::cout << "=== Creating Multi-Dimensional Tensors ===\n";
+    // // Step 2: Creating multi-dimensional tensors
+    // // Define a 2x3 tensor with explicit values
+    // Tensor d = Tensor({1,2,3,4,5,6}, {2, 3}, true);
     
-    // Create a random 2x3 tensor with autograd enabled
-    Tensor e = Tensor::randn({2, 3}, true);
-    std::cout << "Random tensor d: " << d << "\n";
+    // // Create a random 2x3 tensor with autograd enabled
+    // Tensor e = Tensor::randn({2, 3}, true);
+    // std::cout << "Random tensor d: " << d << "\n";
 
-    std::cout << "=== Sum and Mean Operations ===\n";
-    // Step 3: Demonstrating sum and mean operations
-    // Compute the sum of all elements in d
-    Tensor f = d.sum();
-    // Compute the mean of all elements in e
-    Tensor g = e.mean();
-    std::cout << "Sum of d: " << f << "\n";
-    std::cout << "Mean of e: " << g << "\n";
+    // std::cout << "=== Sum and Mean Operations ===\n";
+    // // Step 3: Demonstrating sum and mean operations
+    // // Compute the sum of all elements in d
+    // Tensor f = d.sum();
+    // // Compute the mean of all elements in e
+    // Tensor g = e.mean();
+    // std::cout << "Sum of d: " << f << "\n";
+    // std::cout << "Mean of e: " << g << "\n";
 
-    std::cout << "=== Reducing to Scalar for Backpropagation ===\n";
-    // Step 4: Reducing a multi-dimensional tensor to a scalar before backpropagation
-    // Perform element-wise multiplication, then sum twice to ensure scalar output
-    Tensor h = (d * e).sum().sum();
-    h.backward(); // Compute gradients
+    // std::cout << "=== Reducing to Scalar for Backpropagation ===\n";
+    // // Step 4: Reducing a multi-dimensional tensor to a scalar before backpropagation
+    // // Perform element-wise multiplication, then sum twice to ensure scalar output
+    // Tensor h = (d * e).sum().sum();
+    // h.backward(); // Compute gradients
     
-    // Print the computed gradients
-    std::cout << "Gradient of d: " << d.grad() << "\n";
-    std::cout << "Gradient of e: " << e.grad() << "\n";
+    // // Print the computed gradients
+    // std::cout << "Gradient of d: " << d.grad() << "\n";
+    // std::cout << "Gradient of e: " << e.grad() << "\n";
 
-    std::cout << "=== Backpropagation ===\n";
-    // Step 5: Computing gradients with a mathematical function
-    // Create a random 3x3 tensor
-    Tensor x = Tensor::randn({3, 3}, true);
+    // std::cout << "=== Backpropagation ===\n";
+    // // Step 5: Computing gradients with a mathematical function
+    // // Create a random 3x3 tensor
+    // Tensor x = Tensor::randn({3, 3}, true);
     
-    // Apply element-wise exponential and logarithm, then compute mean and sum
-    Tensor y = (x.exp() + x.log()).mean().sum();
-    y.backward(); // Compute gradients
+    // // Apply element-wise exponential and logarithm, then compute mean and sum
+    // Tensor y = (x.exp() + x.log()).mean().sum();
+    // y.backward(); // Compute gradients
     
-    std::cout << "Gradient of x: " << x.grad() << "\n";
+    // std::cout << "Gradient of x: " << x.grad() << "\n";
 
-    std::cout << "=== Multi-Dimensional Tensors ===\n";
-    // Step 6: Performing more complex tensor operations
-    // Creating three 4x4 random tensors
-    Tensor m1 = Tensor::randn({4, 4}, true);
-    Tensor m2 = Tensor::randn({4, 4}, true);
-    Tensor m3 = Tensor::randn({4, 4}, true);
+    // std::cout << "=== Multi-Dimensional Tensors ===\n";
+    // // Step 6: Performing more complex tensor operations
+    // // Creating three 4x4 random tensors
+    // Tensor m1 = Tensor::randn({4, 4}, true);
+    // Tensor m2 = Tensor::randn({4, 4}, true);
+    // Tensor m3 = Tensor::randn({4, 4}, true);
     
-    // Compute result using element-wise multiplication and addition
-    Tensor result = m1 * m2 + m3;
-    result.sum().sum().backward(); // Reduce to scalar and compute gradients
+    // // Compute result using element-wise multiplication and addition
+    // Tensor result = m1 * m2 + m3;
+    // result.sum().sum().backward(); // Reduce to scalar and compute gradients
     
-    std::cout << "Gradient of m1: " << m1.grad() << "\n";
+    // std::cout << "Gradient of m1: " << m1.grad() << "\n";
 
-    std::cout << "=== Broadcasting Capabilities ===\n";
-    // Step 7: Demonstrating broadcasting capabilities
-    // Define a scalar tensor and a larger 2x3 tensor
-    Tensor small = Tensor({3.0}, true);
-    Tensor large = Tensor::randn({2, 3}, true);
+    // std::cout << "=== Broadcasting Capabilities ===\n";
+    // // Step 7: Demonstrating broadcasting capabilities
+    // // Define a scalar tensor and a larger 2x3 tensor
+    // Tensor small = Tensor({3.0}, true);
+    // Tensor large = Tensor::randn({2, 3}, true);
     
-    // Broadcasting: small is expanded to match the shape of large
-    Tensor broadcasted = small * large;
-    std::cout << "Broadcasted multiplication: " << broadcasted << "\n";
+    // // Broadcasting: small is expanded to match the shape of large
+    // Tensor broadcasted = small * large;
+    // std::cout << "Broadcasted multiplication: " << broadcasted << "\n";
     
-    // Reduce to scalar before backpropagation
-    broadcasted.sum().sum().backward();
-    std::cout << "Gradient of small: " << small.grad() << "\n";
+    // // Reduce to scalar before backpropagation
+    // broadcasted.sum().sum().backward();
+    // std::cout << "Gradient of small: " << small.grad() << "\n";
+
+    Tensor a_cpp = Tensor({1,2, 3, 4, 5, 6}, {2, 3}, true);
+    Tensor exp_tensor = a_cpp;
+    Tensor sum_exp = exp_tensor.sum() + 1e-6; /* Add a small epsilon to avoid division by zero */
+    sum_exp.ptr->shape.insert(sum_exp.ptr->shape.begin() + 1, 1);
+    Tensor d_cpp =  exp_tensor / sum_exp;
+    Tensor c_cpp = d_cpp.sum().sum();
+    c_cpp.backward();
+
+    std::cout << "test" << std::endl;
+
+    Tensor a = Tensor({1,2, 3, 4, 5, 6}, {2, 3}, true);
+    Tensor d = a.sum() + 1e-6;
+    Tensor c = d.sum();
+    c.backward();
+
+
+    
+    // torch::Tensor a_torch = torch::tensor({{1, 2, 3}, {4, 5, 6}}, torch::dtype(torch::kFloat32).requires_grad(true));
+    // a_torch.retain_grad();
+    // torch::Tensor exp_tensor_torch = a_torch;
+    // exp_tensor_torch.retain_grad();
+    // torch::Tensor sum_exp_torch = exp_tensor_torch.sum(1) + 1e-6;
+    // sum_exp_torch = sum_exp_torch.unsqueeze(1);
+    // sum_exp_torch.retain_grad();
+    // torch::Tensor d_torch = exp_tensor_torch / sum_exp_torch;
+    // d_torch.retain_grad();
+    // torch::Tensor c_torch = d_torch.sum().sum();
+    // c_torch.backward();
+
+
+    // std::cout << "c_cpp: " << c_cpp << std::endl;
+    // std::cout << "c_torch: " << c_torch << std::endl;
+
+    // std::cout << "exp_tensor_cpp id " << exp_tensor.ptr->id << std::endl;
+    // std::cout << "exp_tensor_cpp.grad(): " << exp_tensor.grad() << std::endl;
+    // std::cout << "exp_tensor_torch.grad(): " << exp_tensor_torch.grad() << std::endl;
+
+    // std::cout << "sum_exp.grad(): " << sum_exp.grad() << std::endl;
+    // std::cout << "sum_exp_torch.grad(): " << sum_exp_torch.grad() << std::endl;
 
     return 0;
 }

--- a/grad/cppgrad.h
+++ b/grad/cppgrad.h
@@ -24,160 +24,6 @@ extern std::mt19937 global_generator;
 /* helper function to set random seed */
 void set_seed(int seed);
 
-
-class Tensor {
-public:
-    /* Global mutex for thread_gradients */
-    static std::mutex GLOBAL_GRAD_MUTEX;      
-    /* Global mutex for parents */
-    static std::mutex GLOBAL_PARENTS_MUTEX;   
-
-    size_t id;
-    std::vector<float> data;
-    std::vector<size_t> shape;
-    bool requires_grad;
-    mutable std::unordered_map<std::thread::id, std::shared_ptr<Tensor>> thread_gradients;
-    std::function<void()> backward_fn;
-    mutable std::unordered_map<std::thread::id, std::unordered_set<std::shared_ptr<Tensor>>> parents;
-
-    /* constructor inferring tensor shape to be 1D */
-    Tensor(const std::vector<float>& data, bool requires_grad = false)
-        : data(data), requires_grad(requires_grad) { 
-        shape = { data.size() };
-        id = get_id();
-
-        if (requires_grad) {
-            std::thread::id tid = std::this_thread::get_id();
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-            thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(data.size(), 0.0f), shape, false);
-        }
-    }
-
-    /* constructor creating a tensor with explicit shape */
-    Tensor(const std::vector<float>& data, const std::vector<size_t>& shape, bool requires_grad = false)
-        : data(data), shape(shape), requires_grad(requires_grad) {
-        /* check if shape matches */
-        if (numel(shape) != data.size()) {
-            throw std::invalid_argument("Data size does not match shape.");
-        }
-        id = get_id();
-
-        if (requires_grad) {
-            std::thread::id tid = std::this_thread::get_id();
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-            thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(data.size(), 0.0f), shape, false);
-        }
-    }
-
-    /* constructor creating a tensor with an explicit shape and gradient */
-    Tensor(const std::vector<float>& data, const std::vector<size_t>& shape, bool requires_grad, std::shared_ptr<Tensor> grad)
-        : data(data), shape(shape), requires_grad(requires_grad) {
-        /* check if shape matches */
-        if (numel(shape) != data.size()) {
-            throw std::invalid_argument("Data size does not match shape.");
-        }
-        id = get_id();
-
-        if (requires_grad) {
-            std::thread::id tid = std::this_thread::get_id();
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-            if (!grad) {
-                grad = std::make_shared<Tensor>(std::vector<float>(data.size(), 0.0f), shape, false);
-            }
-            thread_gradients[tid] = grad;
-        }
-    }
-
-    /* backward function */
-    void backward();
-
-    /* binary addition operator */
-    Tensor operator+(const Tensor& other) const;
-    Tensor operator+(const float other) const;
-    /* binary minus operator */
-    Tensor operator-(const Tensor& other) const;
-    Tensor operator-(const float other) const;
-    /* unary minus operator */
-    Tensor operator-() const;
-    /* elementwise multiplication operator */
-    Tensor operator*(const Tensor& other) const;
-    Tensor operator*(const float other) const;
-    /* elementwise division operator */
-    Tensor operator/(const Tensor& other) const;
-    Tensor operator/(const float other) const;
-    /* overload the << operator */
-    friend std::ostream& operator<<(std::ostream& os, const Tensor& tensor);
-    /* matrix multiplication */
-    Tensor matmul(const Tensor &other) const;
-    /* sum over given dimension */
-    Tensor sum(const size_t dim) const;
-    /* sum over trailing dimension */
-    Tensor sum() const;
-    /* mean over given dimension */
-    Tensor mean(const size_t dim) const;
-    /* mean over trailing dimension */
-    Tensor mean() const;
-    /* exp tensor */
-    Tensor exp() const;
-    /* log tensor */
-    Tensor log() const;
-    /* softmax over dimension */
-    Tensor softmax(size_t dim) const;
-    /* softmax */
-    Tensor softmax() const;
-    /* one hot-encode */
-    Tensor onehot_encode(size_t num_classes) const;
-    /* activation function */
-    Tensor relu() const;
-
-    /* initialization functions: */
-
-    /* 
-     * initialize a random tensor
-     * each element is sampled from U[0, 1]
-     */
-    static Tensor randn(const std::vector<size_t>& shape, bool requires_grad); 
-
-    /*
-     * initialize a random tensor using He initialization
-     * sampled from a uniform distribution scaled by stddev.
-     */
-    static Tensor randn_he(size_t in_features, size_t out_features, bool requires_grad);
-        
-    /*
-     * initialize a bias tensor with values sampled uniformly from [-bound, bound],
-     * where bound = 1 / sqrt(in_features), following PyTorch's bias initialization.
-     */
-    static Tensor bias_uniform(size_t in_features, bool requires_grad);
-
-    /* helper functions: */
-    
-    /* helper function zeroing out the gradient */
-    void zero_grad();
-    /* helper function to count the number of elements */
-    static size_t numel(const std::vector<size_t>& shp);
-    /* helper function to print the shape of a tensor */
-    void print_shape() const; 
-    /* helper function to print a tensor */
-    void print_recursive(std::ostream& os, size_t dim, size_t offset, size_t stride) const; 
-    /* helper function returning the gradient tensor */
-    Tensor grad() const;
-    /* disable gradient computation */
-    void eval();
-    /* enable gradient computation */
-    void train();
-   private:
-};
-
-/* Loss functions: */
-
-/* 
- * Cross Entropy Loss
- * y_pred: Tensor of shape (batch_size, num_classes)
- * y_true: Tensor of shape (batch_size)
- */
-Tensor CrossEntropyLoss(const Tensor& y_pred, const Tensor& y_true);
-
 /* Utility functions: */
 
 /* 
@@ -210,11 +56,192 @@ std::vector<float> reduce_grad(const std::vector<float>& grad,
         const std::vector<size_t>& grad_shape, 
         const std::vector<size_t>& original_shape);
 
+/* helper function to count the number of elements */
+size_t numel(const std::vector<size_t>& shp);
 
 /* helper function to print tensor shape */
 void printShape(const std::vector<size_t>& shape);
+
 /* hel[er function to print two tensor shapes */
 void printShapes(const std::vector<size_t>& shape1, const std::vector<size_t>& shape2);
-/* helper function printing the gradient */
+
+class TensorData {
+public:
+    /* Global mutex for thread_gradients */
+    static std::mutex GLOBAL_GRAD_MUTEX;      
+    /* Global mutex for parents */
+    static std::mutex GLOBAL_PARENTS_MUTEX;
+
+    size_t id;
+    std::vector<float> data;
+    std::vector<size_t> shape;
+    bool requires_grad;
+    mutable std::unordered_map<std::thread::id, std::shared_ptr<TensorData>> thread_gradients;
+    std::function<void()> backward_fn;
+    mutable std::unordered_map<std::thread::id, std::unordered_set<std::shared_ptr<TensorData>>> parents;
+
+    /* constructor inferring tensor shape to be 1D */
+    TensorData(const std::vector<float>& data, bool requires_grad = false)
+        : data(data), requires_grad(requires_grad) { 
+            std::cout << "Creating tensor with explicit shape and gradient" << std::endl;
+            shape = { data.size() };
+            id = get_id();
+
+            if (requires_grad) {
+                std::thread::id tid = std::this_thread::get_id();
+                std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+                thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(data.size(), 0.0f), shape, false);
+            }
+    }
+
+    /* constructor creating a tensor with explicit shape */
+    TensorData(const std::vector<float>& data, const std::vector<size_t>& shape, bool requires_grad = false)
+        : data(data), shape(shape), requires_grad(requires_grad) {
+            std::cout << "Creating tensor with explicit shape and gradient" << std::endl;
+            /* check if shape matches */
+            if (numel(shape) != data.size()) {
+                throw std::invalid_argument("Data size does not match shape.");
+            }
+            id = get_id();
+
+            if (requires_grad) {
+                std::thread::id tid = std::this_thread::get_id();
+                std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+                thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(data.size(), 0.0f), shape, false);
+            }
+    }
+
+    /* constructor creating a tensor with an explicit shape and gradient */
+    TensorData(const std::vector<float>& data, const std::vector<size_t>& shape, bool requires_grad, std::shared_ptr<TensorData> grad)
+        : data(data), shape(shape), requires_grad(requires_grad) {
+            std::cout << "Creating tensor with explicit shape and gradient" << std::endl;
+            /* check if shape matches */
+            if (numel(shape) != data.size()) {
+                throw std::invalid_argument("Data size does not match shape.");
+            }
+            id = get_id();
+
+            if (requires_grad) {
+                std::thread::id tid = std::this_thread::get_id();
+                std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+                if (!grad) {
+                    grad = std::make_shared<TensorData>(std::vector<float>(data.size(), 0.0f), shape, false);
+                }
+                thread_gradients[tid] = grad;
+            }
+    }
+
+   private:
+};
+
+class Tensor {
+    public:
+
+    std::shared_ptr<TensorData> ptr;
+
+    Tensor(const std::vector<float>& data, bool requires_grad = false) {
+        this->ptr = std::make_shared<TensorData>(data, requires_grad);
+    }
+
+    Tensor(const std::vector<float>& data, const std::vector<size_t>& shape, bool requires_grad = false) {
+        this->ptr = std::make_shared<TensorData>(data, shape, requires_grad);
+    }
+
+    Tensor(const std::vector<float>& data, const std::vector<size_t>& shape, bool requires_grad, std::shared_ptr<TensorData> grad) {
+        this->ptr = std::make_shared<TensorData>(data, shape, requires_grad, grad);
+    }
+
+    Tensor(std::shared_ptr<TensorData> ptr) : ptr(ptr) {}
+
+    Tensor() : ptr(NULL) {}
+
+    /* backward function */
+    void backward();
+
+    /* binary addition operator */
+    Tensor operator+(const Tensor& other) const;
+    Tensor operator+(const float other) const;
+    // /* binary minus operator */
+    // Tensor operator-(const Tensor& other) const;
+    // Tensor operator-(const float other) const;
+    // /* unary minus operator */
+    // Tensor operator-() const;
+    /* elementwise multiplication operator */
+    Tensor operator*(const Tensor& other) const;
+    Tensor operator*(const float other) const;
+    // /* elementwise division operator */
+    // Tensor operator/(const Tensor& other) const;
+    // Tensor operator/(const float other) const;
+    /* overload the << operator */
+    friend std::ostream& operator<<(std::ostream& os, const Tensor& tensor);
+    // /* matrix multiplication */
+    // Tensor matmul(const Tensor &other) const;
+    // /* sum over given dimension */
+    // Tensor sum(const size_t dim) const;
+    // /* sum over trailing dimension */
+    // Tensor sum() const;
+    // /* mean over given dimension */
+    // Tensor mean(const size_t dim) const;
+    // /* mean over trailing dimension */
+    // Tensor mean() const;
+    // /* exp tensor */
+    // Tensor exp() const;
+    // /* log tensor */
+    // Tensor log() const;
+    // /* softmax over dimension */
+    // Tensor softmax(size_t dim) const;
+    // /* softmax */
+    // Tensor softmax() const;
+    // /* one hot-encode */
+    // Tensor onehot_encode(size_t num_classes) const;
+    // /* activation function */
+    // Tensor relu() const;
+
+    // /* initialization functions: */
+
+    // /* 
+    //  * initialize a random tensor
+    //  * each element is sampled from U[0, 1]
+    //  */
+    // static Tensor randn(const std::vector<size_t>& shape, bool requires_grad); 
+
+    // /*
+    //  * initialize a random tensor using He initialization
+    //  * sampled from a uniform distribution scaled by stddev.
+    //  */
+    // static Tensor randn_he(size_t in_features, size_t out_features, bool requires_grad);
+        
+    // /*
+    //  * initialize a bias tensor with values sampled uniformly from [-bound, bound],
+    //  * where bound = 1 / sqrt(in_features), following PyTorch's bias initialization.
+    //  */
+    // static Tensor bias_uniform(size_t in_features, bool requires_grad);
+
+    // /* helper functions: */
+    
+    /* helper function zeroing out the gradient */
+    void zero_grad();
+    /* helper function to print the shape of a tensor */
+    void print_shape() const; 
+    /* helper function to print a tensor */
+    void print_recursive(std::ostream& os, size_t dim, size_t offset, size_t stride) const; 
+    /* helper function returning the gradient tensor */
+    Tensor grad() const;
+    /* disable gradient computation */
+    void eval();
+    /* enable gradient computation */
+    void train();
+
+    private:
+};
+
+/* Loss functions: */
+
+/* 
+ * Cross Entropy Loss
+ * y_pred: Tensor of shape (batch_size, num_classes)
+ * y_true: Tensor of shape (batch_size)
+ */
+Tensor CrossEntropyLoss(const Tensor& y_pred, const Tensor& y_true);
 
 #endif // CPPGRAD_H

--- a/grad/cppgrad.h
+++ b/grad/cppgrad.h
@@ -83,7 +83,6 @@ public:
     /* constructor inferring tensor shape to be 1D */
     TensorData(const std::vector<float>& data, bool requires_grad = false)
         : data(data), requires_grad(requires_grad) { 
-            std::cout << "Creating tensor with explicit shape and gradient" << std::endl;
             shape = { data.size() };
             id = get_id();
 
@@ -97,7 +96,6 @@ public:
     /* constructor creating a tensor with explicit shape */
     TensorData(const std::vector<float>& data, const std::vector<size_t>& shape, bool requires_grad = false)
         : data(data), shape(shape), requires_grad(requires_grad) {
-            std::cout << "Creating tensor with explicit shape and gradient" << std::endl;
             /* check if shape matches */
             if (numel(shape) != data.size()) {
                 throw std::invalid_argument("Data size does not match shape.");
@@ -114,7 +112,6 @@ public:
     /* constructor creating a tensor with an explicit shape and gradient */
     TensorData(const std::vector<float>& data, const std::vector<size_t>& shape, bool requires_grad, std::shared_ptr<TensorData> grad)
         : data(data), shape(shape), requires_grad(requires_grad) {
-            std::cout << "Creating tensor with explicit shape and gradient" << std::endl;
             /* check if shape matches */
             if (numel(shape) != data.size()) {
                 throw std::invalid_argument("Data size does not match shape.");
@@ -161,70 +158,74 @@ class Tensor {
     /* binary addition operator */
     Tensor operator+(const Tensor& other) const;
     Tensor operator+(const float other) const;
-    // /* binary minus operator */
-    // Tensor operator-(const Tensor& other) const;
-    // Tensor operator-(const float other) const;
-    // /* unary minus operator */
-    // Tensor operator-() const;
+    /* binary minus operator */
+    Tensor operator-(const Tensor& other) const;
+    Tensor operator-(const float other) const;
+    /* unary minus operator */
+    Tensor operator-() const;
     /* elementwise multiplication operator */
     Tensor operator*(const Tensor& other) const;
     Tensor operator*(const float other) const;
     // /* elementwise division operator */
-    // Tensor operator/(const Tensor& other) const;
-    // Tensor operator/(const float other) const;
+    Tensor operator/(const Tensor& other) const;
+    Tensor operator/(const float other) const;
     /* overload the << operator */
     friend std::ostream& operator<<(std::ostream& os, const Tensor& tensor);
-    // /* matrix multiplication */
-    // Tensor matmul(const Tensor &other) const;
-    // /* sum over given dimension */
-    // Tensor sum(const size_t dim) const;
-    // /* sum over trailing dimension */
-    // Tensor sum() const;
-    // /* mean over given dimension */
-    // Tensor mean(const size_t dim) const;
-    // /* mean over trailing dimension */
-    // Tensor mean() const;
-    // /* exp tensor */
-    // Tensor exp() const;
-    // /* log tensor */
-    // Tensor log() const;
-    // /* softmax over dimension */
-    // Tensor softmax(size_t dim) const;
-    // /* softmax */
-    // Tensor softmax() const;
-    // /* one hot-encode */
-    // Tensor onehot_encode(size_t num_classes) const;
-    // /* activation function */
-    // Tensor relu() const;
+    /* matrix multiplication */
+    Tensor matmul(const Tensor &other) const;
+    /* sum over given dimension */
+    Tensor sum(const size_t dim) const;
+    /* sum over trailing dimension */
+    Tensor sum() const;
+    /* mean over given dimension */
+    Tensor mean(const size_t dim) const;
+    /* mean over trailing dimension */
+    Tensor mean() const;
+    /* exp tensor */
+    Tensor exp() const;
+    /* log tensor */
+    Tensor log() const;
+    /* softmax over dimension */
+    Tensor softmax(size_t dim) const;
+    /* softmax */
+    Tensor softmax() const;
+    /* one hot-encode */
+    Tensor onehot_encode(size_t num_classes) const;
+    /* activation function */
+    Tensor relu() const;
 
-    // /* initialization functions: */
+    /* initialization functions: */
 
-    // /* 
-    //  * initialize a random tensor
-    //  * each element is sampled from U[0, 1]
-    //  */
-    // static Tensor randn(const std::vector<size_t>& shape, bool requires_grad); 
+    /* 
+     * initialize a random tensor
+     * each element is sampled from U[0, 1]
+     */
+    static Tensor randn(const std::vector<size_t>& shape, bool requires_grad); 
 
-    // /*
-    //  * initialize a random tensor using He initialization
-    //  * sampled from a uniform distribution scaled by stddev.
-    //  */
-    // static Tensor randn_he(size_t in_features, size_t out_features, bool requires_grad);
+    /*
+     * initialize a random tensor using He initialization
+     * sampled from a uniform distribution scaled by stddev.
+     */
+    static Tensor randn_he(size_t in_features, size_t out_features, bool requires_grad);
         
-    // /*
-    //  * initialize a bias tensor with values sampled uniformly from [-bound, bound],
-    //  * where bound = 1 / sqrt(in_features), following PyTorch's bias initialization.
-    //  */
-    // static Tensor bias_uniform(size_t in_features, bool requires_grad);
+    /*
+     * initialize a bias tensor with values sampled uniformly from [-bound, bound],
+     * where bound = 1 / sqrt(in_features), following PyTorch's bias initialization.
+     */
+    static Tensor bias_uniform(size_t in_features, bool requires_grad);
 
     // /* helper functions: */
-    
+
     /* helper function zeroing out the gradient */
     void zero_grad();
     /* helper function to print the shape of a tensor */
     void print_shape() const; 
     /* helper function to print a tensor */
     void print_recursive(std::ostream& os, size_t dim, size_t offset, size_t stride) const; 
+    /* helper function returning the shape of a tensor */
+    std::vector<size_t> shape() const;
+    /* helper function returning the data of a tensor */
+    std::vector<float> data() const;
     /* helper function returning the gradient tensor */
     Tensor grad() const;
     /* disable gradient computation */

--- a/grad/initialization_functions.cpp
+++ b/grad/initialization_functions.cpp
@@ -6,7 +6,7 @@
  */
 Tensor Tensor::randn(const std::vector<size_t>& shape, bool requires_grad = false) {
     /* allocate memory for tensor */
-    size_t total_elems = Tensor::numel(shape);
+    size_t total_elems = numel(shape);
     std::vector<float> data(total_elems);
 
     std::uniform_real_distribution<float> distribution(0.0, 1.0);

--- a/grad/matmul.cpp
+++ b/grad/matmul.cpp
@@ -135,8 +135,18 @@ void matmul_transposed_tiled(const std::vector<float>& A,
  */
 Tensor Tensor::matmul(const Tensor &other) const {
     
+    auto this_shape = this->ptr->shape;
+    auto other_shape = other.ptr->shape;
+
+    auto this_data = this->ptr->data;
+    auto other_data = other.ptr->data;
+
+    auto this_requires_grad = this->ptr->requires_grad;
+    auto other_requires_grad = other.ptr->requires_grad;
+    auto result_requires_grad = this->ptr->requires_grad || other.ptr->requires_grad;
+
     /* ensure that both tensors have at least two dimensions */
-    if (shape.size() < 2 || other.shape.size() < 2) {
+    if (this_shape.size() < 2 || other_shape.size() < 2) {
         throw std::invalid_argument(
             "Both tensors must have at least 2 dimensions for matmul."
         );
@@ -146,10 +156,10 @@ Tensor Tensor::matmul(const Tensor &other) const {
      * A in [batch_dims..., m, n]
      * B in [batch_dims..., x, p]
      */
-    size_t m = shape[shape.size() - 2];
-    size_t n = shape[shape.size() - 1];
-    size_t x = other.shape[other.shape.size() - 2];
-    size_t p = other.shape[other.shape.size() - 1];
+    size_t m = this_shape[this_shape.size() - 2];
+    size_t n = this_shape[this_shape.size() - 1];
+    size_t x = other_shape[other_shape.size() - 2];
+    size_t p = other_shape[other_shape.size() - 1];
 
     if (n != x) {
         throw std::invalid_argument(
@@ -166,11 +176,11 @@ Tensor Tensor::matmul(const Tensor &other) const {
      * if either tensor has extra dims (beyond the last 2),
      * broadcast those leading dims
      */
-    if (shape.size() > 2 || other.shape.size() > 2) {
+    if (this_shape.size() > 2 || other_shape.size() > 2) {
         this_batch_shape =
-            std::vector<size_t>(shape.begin(), shape.end() - 2);
+            std::vector<size_t>(this_shape.begin(), this_shape.end() - 2);
         other_batch_shape =
-            std::vector<size_t>(other.shape.begin(), other.shape.end() - 2);
+            std::vector<size_t>(other_shape.begin(), other_shape.end() - 2);
 
         /* broadcast returns the broadcasted shape, empty if shapes are not broadcastable */
         batch_shape = broadcast(this_batch_shape, other_batch_shape);
@@ -202,95 +212,75 @@ Tensor Tensor::matmul(const Tensor &other) const {
     for (size_t b = 0; b < batch_size; ++b) {
         std::vector<size_t> batch_index = unravel_index(b, batch_shape);
     
-        this_offsets[b] = ravel_index(batch_index, std::vector<size_t>(this->shape.begin(), this->shape.end() - 2)) * m * n;
-        other_offsets[b] = ravel_index(batch_index, std::vector<size_t>(other.shape.begin(), other.shape.end() - 2)) * n * p;
+        this_offsets[b] = ravel_index(batch_index, std::vector<size_t>(this_shape.begin(), this_shape.end() - 2)) * m * n;
+        other_offsets[b] = ravel_index(batch_index, std::vector<size_t>(other_shape.begin(), other_shape.end() - 2)) * n * p;
         result_offsets[b] = b * (m * p);
     }
-    matmul_tiled(this->data, other.data, result_data,
+    matmul_tiled(this_data, other_data, result_data,
                             m, n, p, batch_size, 
                             this_offsets, other_offsets, result_offsets);
     /* construct backward function */
-    std::shared_ptr<Tensor> result = std::make_shared<Tensor>(result_data, result_shape, requires_grad || other.requires_grad);
+    Tensor result = Tensor(result_data, result_shape, result_requires_grad);
     /* construct backward function */
-    if (result->requires_grad) {
-        /*
-        * copy data necessary for backward function
-        * to avoid dangling references
-        */
-        auto this_requires_grad  = requires_grad;
-        auto other_requires_grad = other.requires_grad;
-
-        auto A_data             = data;
-        auto B_data             = other.data;
-
-        auto this_backward_fn   = this->backward_fn;
-        auto other_backward_fn  = other.backward_fn;
-
-        auto saved_this_shape  = shape;
-        auto saved_other_shape = other.shape;
-        auto saved_result_shape = result_shape;
-        auto saved_batch_shape = batch_shape;
-
-        size_t mm = m;
-        size_t nn = n;
-        size_t pp = p;
+    if (result_requires_grad) {
 
          std::thread::id tid = std::this_thread::get_id();
 
         /* add result to computation graph */
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_PARENTS_MUTEX);
             if (this_requires_grad) {
-                auto parent = std::make_shared<Tensor>(*this);
-                /* should be the same tensor in the computation graph */
-                parent->id = this->id;
-                result->parents[tid].insert(parent);
+                result.ptr->parents[tid].insert(this->ptr);
             }
         }
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_PARENTS_MUTEX);
             if (other_requires_grad) {
-                auto parent = std::make_shared<Tensor>(other);
-                /* should be the same tensor in the computation graph */
-                parent->id = other.id;
-                result->parents[tid].insert(parent);
+                result.ptr->parents[tid].insert(other.ptr);
             }
         }
         
         /* Ensure thread-local gradients are initialized */
-        std::shared_ptr<Tensor> this_grad, other_grad;
+        std::shared_ptr<TensorData> this_grad, other_grad;
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_GRAD_MUTEX);
             if (this_requires_grad) {
-                if (!this->thread_gradients[tid]) {
-                    this->thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(this->data.size(), 0.0f), this->shape, false);
+                if (!this->ptr->thread_gradients[tid]) {
+                    this->ptr->thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(this_data.size(), 0.0f), this_shape, false);
                 }
-                this_grad = this->thread_gradients[tid];
+                this_grad = this->ptr->thread_gradients[tid];
             }
         }
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_GRAD_MUTEX);
             if (other_requires_grad) {
-                if (!other.thread_gradients[tid]) {
-                    other.thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(other.data.size(), 0.0f), other.shape, false);
+                if (!other.ptr->thread_gradients[tid]) {
+                    other.ptr->thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(other_data.size(), 0.0f), other_shape, false);
                 }
-                other_grad = other.thread_gradients[tid];
+                other_grad = other.ptr->thread_gradients[tid];
             }
         }
 
-        result->backward_fn = [
-            this_requires_grad, other_requires_grad,
-            this_grad, other_grad,
-            result, A_data, B_data,
-            this_backward_fn, other_backward_fn,
-            saved_this_shape, saved_other_shape, saved_result_shape,
-            saved_batch_shape, mm, nn, pp
-        ]() {
+        result.ptr->backward_fn = [this_ptr = this->ptr, other_ptr = other.ptr, result_ptr = result.ptr, batch_shape = batch_shape, m, n, p]() {
+       
             std::thread::id tid = std::this_thread::get_id();
+
+            auto this_shape = this_ptr->shape;
+            auto other_shape = other_ptr->shape;
+            auto result_shape = result_ptr->shape;
+
+            auto this_data = this_ptr->data;
+            auto other_data = other_ptr->data;
+            auto result_data = result_ptr->data;
+
+            auto this_grad = this_ptr->thread_gradients[tid];
+            auto other_grad = other_ptr->thread_gradients[tid];
+            auto result_grad = result_ptr->thread_gradients[tid]->data;
+
 
             /* compute number of batches */
             size_t batch_size = 1;
-            for (auto d : saved_batch_shape) {
+            for (auto d : batch_shape) {
                 batch_size *= d;
             }
 
@@ -299,31 +289,32 @@ Tensor Tensor::matmul(const Tensor &other) const {
             std::vector<size_t> C_offsets(batch_size, 0);
 
             for (size_t b = 0; b < batch_size; ++b) {
-                std::vector<size_t> batch_index = unravel_index(b, saved_batch_shape);
+                std::vector<size_t> batch_index = unravel_index(b, batch_shape);
                 
-                A_offsets[b] = ravel_index(batch_index, std::vector<size_t>(saved_this_shape.begin(), saved_this_shape.end() - 2)) * mm * nn;
-                B_offsets[b] = ravel_index(batch_index, std::vector<size_t>(saved_other_shape.begin(), saved_other_shape.end() - 2)) * nn * pp;
-                C_offsets[b] = b * (mm * pp);
+                A_offsets[b] = ravel_index(batch_index, std::vector<size_t>(this_shape.begin(), this_shape.end() - 2)) * m * n;
+                B_offsets[b] = ravel_index(batch_index, std::vector<size_t>(other_shape.begin(), other_shape.end() - 2)) * n * p;
+                C_offsets[b] = b * (m * p);
             }
+
             /* dA = dC * B^T */
-            if (this_requires_grad && this_grad) {
-                matmul_transposed_tiled(result->thread_gradients[tid]->data, saved_result_shape, 
-                                    B_data, saved_other_shape, 
-                                    this_grad->data, saved_this_shape, 
-                                    saved_batch_shape,
+            if (this_ptr->requires_grad && this_grad) {
+                matmul_transposed_tiled(result_grad, result_shape, 
+                                    other_data, other_shape, 
+                                    this_grad->data, this_shape, 
+                                    batch_shape,
                                     C_offsets, B_offsets, A_offsets,
-                                    mm, pp, nn,
+                                    m, p, n,
                                     false, true); // No transpose on dC, transpose B
             }
 
             /* dB = A^T * dC */
-            if (other_requires_grad && other_grad) {
-                matmul_transposed_tiled(A_data, saved_this_shape, 
-                                    result->thread_gradients[tid]->data, saved_result_shape, 
-                                    other_grad->data, saved_other_shape, 
-                                    saved_batch_shape,
+            if (other_ptr->requires_grad && other_grad) {
+                matmul_transposed_tiled(this_data, this_shape, 
+                                    result_grad, result_shape, 
+                                    other_grad->data, other_shape, 
+                                    batch_shape,
                                     A_offsets, C_offsets, B_offsets,
-                                    nn, mm, pp,
+                                    n, m, p,
                                     true, false); // Transpose A, no transpose on dC
             }
 
@@ -332,5 +323,5 @@ Tensor Tensor::matmul(const Tensor &other) const {
         
     }
 
-    return *result;
+    return result;
 }

--- a/grad/operator_overloads.cpp
+++ b/grad/operator_overloads.cpp
@@ -10,10 +10,21 @@
  */
 Tensor Tensor::operator+(const Tensor& other) const{
     
+    auto this_shape = this->ptr->shape;
+    auto other_shape = other.ptr->shape;
+
+    auto this_data = this->ptr->data;
+    auto other_data = other.ptr->data;
+
+    auto this_requires_grad = this->ptr->requires_grad;
+    auto other_requires_grad = other.ptr->requires_grad;
+    auto result_requires_grad = this_requires_grad || other_requires_grad;
+
+
     /* infer result shape */
-    std::vector<size_t> result_shape = broadcast(this->shape, other.shape);
+    std::vector<size_t> result_shape = broadcast(this_shape, other_shape);
     if (result_shape.empty()) {
-        printShapes(this->shape, other.shape);
+        printShapes(this_shape, other_shape);
         throw std::invalid_argument("Tensor shapes must be broadcastable for addition.");
     }
 
@@ -24,83 +35,73 @@ Tensor Tensor::operator+(const Tensor& other) const{
     /* iterate over result data and perform addition */
     for (size_t i = 0; i < result_size; ++i) {
         std::vector<size_t> multi_index = unravel_index(i, result_shape);
-        size_t index_a = ravel_index(multi_index, this->shape);
-        size_t index_b = ravel_index(multi_index, other.shape);
-        result_data[i] = this->data[index_a] + other.data[index_b];
+        size_t index_a = ravel_index(multi_index, this_shape);
+        size_t index_b = ravel_index(multi_index, other_shape);
+        result_data[i] = (this_data[index_a]) + other_data[index_b];
     }
 
     /* allocate result tensor */
-    std::shared_ptr<Tensor> result = std::make_shared<Tensor>(result_data, result_shape, requires_grad || other.requires_grad);
+    Tensor result = Tensor(result_data, result_shape, result_requires_grad);
 
     /* construct backward function */
-    if (result->requires_grad) {
-        auto this_requires_grad = this->requires_grad;
-        auto other_requires_grad = other.requires_grad;
-        auto this_shape = this->shape;
-        auto other_shape = other.shape;
-        auto result_shape = result->shape;
+    if (result_requires_grad) {
 
         std::thread::id tid = std::this_thread::get_id();
 
         /* add result to computation graph */
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_PARENTS_MUTEX);
             if (this_requires_grad) {
-                auto parent = std::make_shared<Tensor>(*this);
-                /* should be same tensor in the computation graph */
-                parent->id = this->id;
-                result->parents[tid].insert(parent);
+                result.ptr->parents[tid].insert(this->ptr);
             }
         }
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_PARENTS_MUTEX);
             if (other_requires_grad) {
-                auto parent = std::make_shared<Tensor>(other);
-                /* should be same tensor in the computation graph */
-                parent->id = other.id;
-                result->parents[tid].insert(parent);
+                result.ptr->parents[tid].insert(other.ptr);
             }
         }
 
         /* Ensure thread-local gradients are initialized */
-        std::shared_ptr<Tensor> this_grad, other_grad;
+        std::shared_ptr<TensorData> this_grad, other_grad;
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-            if (this_requires_grad) {
-                if (!this->thread_gradients[tid]) {
-                    this->thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(this->data.size(), 0.0f), this_shape, false);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_GRAD_MUTEX);
+            if (this->ptr->requires_grad) {
+                if (!this->ptr->thread_gradients[tid]) {
+                    this->ptr->thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(this->ptr->data.size(), 0.0f), this_shape, false);
                 }
-                this_grad = this->thread_gradients[tid];
+                this_grad = this->ptr->thread_gradients[tid];
             }
         }
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-            if (other_requires_grad) {
-                if (!other.thread_gradients[tid]) {
-                    other.thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(other.data.size(), 0.0f), other_shape, false);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_GRAD_MUTEX);
+            if (other.ptr->requires_grad) {
+                if (!other.ptr->thread_gradients[tid]) {
+                    other.ptr->thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(other.ptr->data.size(), 0.0f), other_shape, false);
                 }
-                other_grad = other.thread_gradients[tid];
+                other_grad = other.ptr->thread_gradients[tid];
             }
         }
 
         /* Capture shared pointers to gradients in backward function */
-        result->backward_fn = [this_requires_grad, other_requires_grad, 
-                               this_grad, other_grad, result, 
-                               this_shape, other_shape]() 
+        result.ptr->backward_fn = [this_ptr = this->ptr, other_ptr = other.ptr, result_ptr = result.ptr]() 
         {
             std::thread::id tid = std::this_thread::get_id();
+            std::cout << "Backward function for addition\n";
 
             /* 1) Gradient w.r.t. x (this->data) */
-            if (this_requires_grad && this_grad) {
-                auto reduced_grad = reduce_grad(result->thread_gradients[tid]->data, result->shape, this_shape);
+            auto this_grad = this_ptr->thread_gradients[tid];
+            if (this_ptr->requires_grad && this_grad) {
+                auto reduced_grad = reduce_grad(result_ptr->thread_gradients[tid]->data, result_ptr->shape, this_ptr->shape);
                 for (size_t i = 0; i < reduced_grad.size(); ++i) {
                     this_grad->data[i] += reduced_grad[i];
                 }
             }
 
             /* 2) Gradient w.r.t. y (other->data) */
-            if (other_requires_grad && other_grad) {
-                auto reduced_grad = reduce_grad(result->thread_gradients[tid]->data, result->shape, other_shape);
+            auto other_grad = other_ptr->thread_gradients[tid];
+            if (other_ptr->requires_grad && other_grad) {
+                auto reduced_grad = reduce_grad(result_ptr->thread_gradients[tid]->data, result_ptr->shape, other_ptr->shape);
                 for (size_t i = 0; i < reduced_grad.size(); ++i) {
                     other_grad->data[i] += reduced_grad[i];
                 }
@@ -108,7 +109,7 @@ Tensor Tensor::operator+(const Tensor& other) const{
         };
     }
 
-    return *result;
+    return result;
 }
 
 /*
@@ -118,83 +119,83 @@ Tensor Tensor::operator+(const float other) const{
     return *this + Tensor({other}, false);
 }
 
-/* 
- * Overloaded unary - operator
- * 1. Negate the data
- * 2. Negate the gradient if necessary
- * 3. Construct the result tensor
- * 4. If necessary, set up the backward function
- */
-Tensor Tensor::operator-() const{
+// /* 
+//  * Overloaded unary - operator
+//  * 1. Negate the data
+//  * 2. Negate the gradient if necessary
+//  * 3. Construct the result tensor
+//  * 4. If necessary, set up the backward function
+//  */
+// Tensor Tensor::operator-() const{
     
-    /* negate data */
-    std::vector<float> result_data(data.size());
-    for (size_t i = 0; i < data.size(); i++) {
-        result_data[i] = -data[i];
-    }
+//     /* negate data */
+//     std::vector<float> result_data(data.size());
+//     for (size_t i = 0; i < data.size(); i++) {
+//         result_data[i] = -data[i];
+//     }
     
-    /* construct result tensor */
-    std::shared_ptr<Tensor> result = std::make_shared<Tensor>(result_data, shape, requires_grad);
+//     /* construct result tensor */
+//     std::shared_ptr<Tensor> result = std::make_shared<Tensor>(result_data, shape, requires_grad);
 
-    /* construct backward function */
-    if (result->requires_grad) {
+//     /* construct backward function */
+//     if (result->requires_grad) {
         
-        /*
-         * copy data necessary for backward function
-         * to avoid dangling references
-         */
-        auto sz = data.size();
-        auto this_requires_grad = this->requires_grad;
-        /* Store parent in a thread-safe manner */
-        std::thread::id tid = std::this_thread::get_id();
-        {
-            std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
-            if (this_requires_grad) result->parents[tid].insert(std::make_shared<Tensor>(*this));
-        }
-        /* Ensure thread-local gradients are initialized */
-        std::shared_ptr<Tensor> this_grad;
-        {
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-            if (this_requires_grad) {
-                if (!this->thread_gradients[tid]) {
-                    this->thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(this->data.size(), 0.0f), this->shape, false);
-                }
-                this_grad = this->thread_gradients[tid];
-            }
-        }
+//         /*
+//          * copy data necessary for backward function
+//          * to avoid dangling references
+//          */
+//         auto sz = data.size();
+//         auto this_requires_grad = this->requires_grad;
+//         /* Store parent in a thread-safe manner */
+//         std::thread::id tid = std::this_thread::get_id();
+//         {
+//             std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
+//             if (this_requires_grad) result->parents[tid].insert(std::make_shared<Tensor>(*this));
+//         }
+//         /* Ensure thread-local gradients are initialized */
+//         std::shared_ptr<Tensor> this_grad;
+//         {
+//             std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+//             if (this_requires_grad) {
+//                 if (!this->thread_gradients[tid]) {
+//                     this->thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(this->data.size(), 0.0f), this->shape, false);
+//                 }
+//                 this_grad = this->thread_gradients[tid];
+//             }
+//         }
 
-        result->backward_fn = [sz,
-                              this_requires_grad, this_grad,
-                              result]() {
-            std::thread::id tid = std::this_thread::get_id();
+//         result->backward_fn = [sz,
+//                               this_requires_grad, this_grad,
+//                               result]() {
+//             std::thread::id tid = std::this_thread::get_id();
 
-            if (this_requires_grad && this_grad) {
+//             if (this_requires_grad && this_grad) {
 
-                for (size_t i = 0; i < sz; i++) {
-                    this_grad->data[i] -= result->thread_gradients[tid]->data[i];
-                }
-            }
-        };
-    }
+//                 for (size_t i = 0; i < sz; i++) {
+//                     this_grad->data[i] -= result->thread_gradients[tid]->data[i];
+//                 }
+//             }
+//         };
+//     }
 
-    return *result;
-}
+//     return *result;
+// }
 
-/* 
- * Overloaded binary - operator
- * using unary - and + operators
- * this - other = this + (-other)
- */
-Tensor Tensor::operator-(const Tensor& other) const{
-    /* a - b =  a + (-b) */
-    return *this + (-other);
-}
-/*
- * Overloaded - operator, for subtracting scalar and tensor
- */
-Tensor Tensor::operator-(const float other) const{
-    return *this - Tensor({other}, false);
-}
+// /* 
+//  * Overloaded binary - operator
+//  * using unary - and + operators
+//  * this - other = this + (-other)
+//  */
+// Tensor Tensor::operator-(const Tensor& other) const{
+//     /* a - b =  a + (-b) */
+//     return *this + (-other);
+// }
+// /*
+//  * Overloaded - operator, for subtracting scalar and tensor
+//  */
+// Tensor Tensor::operator-(const float other) const{
+//     return *this - Tensor({other}, false);
+// }
 
 /* 
  * Overloaded * operator, does support broadcasting
@@ -206,12 +207,22 @@ Tensor Tensor::operator-(const float other) const{
  */
 Tensor Tensor::operator*(const Tensor& other) const {
     
+    auto this_shape = this->ptr->shape;
+    auto other_shape = other.ptr->shape;
+
+    auto this_data = this->ptr->data;
+    auto other_data = other.ptr->data;
+
+    auto this_requires_grad = this->ptr->requires_grad;
+    auto other_requires_grad = other.ptr->requires_grad;
+    auto result_requires_grad = this_requires_grad || other_requires_grad;
+
     /* infer result shape */
     std::vector<size_t> result_shape;
-    result_shape = broadcast(this->shape, other.shape);
+    result_shape = broadcast(this_shape, other_shape);
     
     if (result_shape.empty()) {
-        printShapes(this->shape, other.shape);
+        printShapes(this_shape, other_shape);
         throw std::invalid_argument("Tensor shapes must be broadcastable for multiplication.");
     }
             
@@ -226,103 +237,88 @@ Tensor Tensor::operator*(const Tensor& other) const {
         std::vector<size_t> multi_index = unravel_index(i, result_shape);
 
         /* map to indices in the original tensors */
-        size_t index_a = ravel_index(multi_index, this->shape);
-        size_t index_b = ravel_index(multi_index, other.shape);
+        size_t index_a = ravel_index(multi_index, this_shape);
+        size_t index_b = ravel_index(multi_index, other_shape);
 
         /* perform addition */
-        result_data[i] = this->data[index_a] * other.data[index_b];
+        result_data[i] = this_data[index_a] * other_data[index_b];
     }
 
     /* allocate result tensor */
-    std::shared_ptr<Tensor> result = std::make_shared<Tensor>(result_data, result_shape, requires_grad || other.requires_grad);
+    Tensor result = Tensor(result_data, result_shape, result_requires_grad);
 
     /* construct backward function */
-    if (result->requires_grad) {
-        /*
-         * copy data necessary for backward function
-         * to avoid dangling references
-         */
-        auto this_requires_grad = this->requires_grad;
-        auto other_requires_grad = other.requires_grad;
-        auto this_backward_fn = this->backward_fn;
-        auto other_backward_fn = other.backward_fn;
-
+    if (result_requires_grad) {
         
         std::thread::id tid = std::this_thread::get_id();
         
         /* add result to computation graph */
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_PARENTS_MUTEX);
             if (this_requires_grad) {
-                auto parent = std::make_shared<Tensor>(*this);
-                /* should be the same tensor in the computation graph */
-                parent->id = this->id;
-                result->parents[tid].insert(parent);
+                result.ptr->parents[tid].insert(this->ptr);
             }
         }
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_PARENTS_MUTEX);
             if (other_requires_grad) {
-                auto parent = std::make_shared<Tensor>(other);
-                /* should be the same tensor in the computation graph */
-                parent->id = other.id;
-                result->parents[tid].insert(parent);
+                result.ptr->parents[tid].insert(other.ptr);
             }
         }
         
         /* Ensure thread-local gradients are initialized */
-        std::shared_ptr<Tensor> this_grad, other_grad;
+        std::shared_ptr<TensorData> this_grad, other_grad;
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_GRAD_MUTEX);
             if (this_requires_grad) {
-                if (!this->thread_gradients[tid]) {
-                    this->thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(this->data.size(), 0.0f), this->shape, false);
+                if (!this->ptr->thread_gradients[tid]) {
+                    this->ptr->thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(this->ptr->data.size(), 0.0f), this_shape, false);
                 }
-                this_grad = this->thread_gradients[tid];
+                this_grad = this->ptr->thread_gradients[tid];
             }
         }
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_GRAD_MUTEX);
             if (other_requires_grad) {
-                if (!other.thread_gradients[tid]) {
-                    other.thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(other.data.size(), 0.0f), other.shape, false);
+                if (!other.ptr->thread_gradients[tid]) {
+                    other.ptr->thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(other.ptr->data.size(), 0.0f), other_shape, false);
                 }
-                other_grad = other.thread_gradients[tid];
+                other_grad = other.ptr->thread_gradients[tid];
             }
         }
 
-        result->backward_fn = [
-                    this_requires_grad, other_requires_grad,
-                    this_grad, other_grad,
-                    this_backward_fn, other_backward_fn,
-                    result, 
-                    this_data = this->data,
-                    other_data = other.data,
-                    this_shape = this->shape,
-                    other_shape = other.shape,
-                    result_shape = result->shape]() 
+        result.ptr->backward_fn = [this_ptr = this->ptr, other_ptr = other.ptr, result_ptr = result.ptr]() 
         {
-
             std::thread::id tid = std::this_thread::get_id();
 
+            auto this_shape = this_ptr->shape;
+            auto other_shape = other_ptr->shape;
+
+            auto this_data = this_ptr->data;
+            auto other_data = other_ptr->data;
+
+            auto result_data = result_ptr->data;
+            auto result_grad = result_ptr->thread_gradients[tid]->data;
+
             /* 1) Gradient w.r.t. x (this->data) */
-            if (this_requires_grad && this_grad) {
+            auto this_grad = this_ptr->thread_gradients[tid];
+            if (this_ptr->requires_grad && this_grad) {
 
                 /* temporary helper varibale to element wise gradient */
-                std::vector<float> partial_grad_x(result->thread_gradients[tid]->data.size(), 0.0f);
+                std::vector<float> partial_grad_x(result_grad.size(), 0.0f);
 
                 /* iterate over result data and compute gradient */
-                for (size_t i = 0; i < result->thread_gradients[tid]->data.size(); ++i) {
+                for (size_t i = 0; i < result_grad.size(); ++i) {
                     /* compute the multi-dimensional index in the result shape */
-                    std::vector<size_t> multi_index = unravel_index(i, result_shape);
+                    std::vector<size_t> multi_index = unravel_index(i, result_ptr->shape);
                     /* map index into other->data */
                     size_t index_b = ravel_index(multi_index, other_shape);
                     /* compute the gradient */
-                    partial_grad_x[i] = result->thread_gradients[tid]->data[i] * other_data[index_b];
+                    partial_grad_x[i] = result_grad[i] * other_data[index_b];
                 }
 
                 /* reduce the gradient by summing over broadcasted dimension */
-                auto reduced_grad_x = reduce_grad(partial_grad_x, result_shape, this_shape);
+                auto reduced_grad_x = reduce_grad(partial_grad_x, result_ptr->shape, this_shape);
                 
                 for (size_t i = 0; i < reduced_grad_x.size(); ++i) {
                     this_grad->data[i] += reduced_grad_x[i];
@@ -331,22 +327,23 @@ Tensor Tensor::operator*(const Tensor& other) const {
             } 
 
             /* 2) Gradient w.r.t. y (other->data) */
-            if (other_requires_grad && other_grad) {
+            auto other_grad = other_ptr->thread_gradients[tid];
+            if (other_ptr->requires_grad && other_grad) {
                 /* temporary helper varibale to element wise gradient */
-                std::vector<float> partial_grad_y(result->thread_gradients[tid]->data.size(), 0.0f);
+                std::vector<float> partial_grad_y(result_grad.size(), 0.0f);
 
                 /* iterate over result data and compute gradient */
-                for (size_t i = 0; i < result->thread_gradients[tid]->data.size(); i++) {
+                for (size_t i = 0; i < result_grad.size(); i++) {
                     /* compute the multi-dimensional index in the result shape */
-                    std::vector<size_t> multi_index = unravel_index(i, result_shape);
+                    std::vector<size_t> multi_index = unravel_index(i, result_ptr->shape);
                     /* map index into this->data */
                     size_t index_a = ravel_index(multi_index, this_shape);
                     /* compute the gradient */
-                    partial_grad_y[i] = result->thread_gradients[tid]->data[i] * this_data[index_a];
+                    partial_grad_y[i] = result_grad[i] * this_data[index_a];
                 }
                 
                 /* reduce the gradient by summing over broadcasted dimension */
-                auto reduced_grad_y = reduce_grad(partial_grad_y, result_shape, other_shape);
+                auto reduced_grad_y = reduce_grad(partial_grad_y, result_ptr->shape, other_shape);
                 
                 for (size_t i = 0; i < reduced_grad_y.size(); ++i) {
                     other_grad->data[i] += reduced_grad_y[i];
@@ -355,7 +352,7 @@ Tensor Tensor::operator*(const Tensor& other) const {
         };
     }
 
-    return *result;
+    return result;
 }
 
 /*
@@ -365,187 +362,187 @@ Tensor Tensor::operator*(const float other) const {
     return *this * Tensor({other}, false);
 }
 
-/* 
- * Overloaded / operator, does support broadcasting
- * 1. Check if tensors are broadcastable
- * 2. iterate over result data
- * 3. construct multi-dimensional index
- * 4. perform division
- * 4. If necessary, set up the backward function
- */
-Tensor Tensor::operator/(const Tensor& other) const {
+// /* 
+//  * Overloaded / operator, does support broadcasting
+//  * 1. Check if tensors are broadcastable
+//  * 2. iterate over result data
+//  * 3. construct multi-dimensional index
+//  * 4. perform division
+//  * 4. If necessary, set up the backward function
+//  */
+// Tensor Tensor::operator/(const Tensor& other) const {
     
-    /* infer result shape */
-    std::vector<size_t> result_shape;
-    result_shape = broadcast(this->shape, other.shape);
+//     /* infer result shape */
+//     std::vector<size_t> result_shape;
+//     result_shape = broadcast(this->shape, other.shape);
     
-    if (result_shape.empty()) {
-        printShapes(this->shape, other.shape);
-        throw std::invalid_argument("Tensor shapes must be broadcastable for division.");
-    }
+//     if (result_shape.empty()) {
+//         printShapes(this->shape, other.shape);
+//         throw std::invalid_argument("Tensor shapes must be broadcastable for division.");
+//     }
             
-    /* allocate memory for result data */
-    size_t result_size = numel(result_shape);
-    std::vector<float> result_data(result_size);
+//     /* allocate memory for result data */
+//     size_t result_size = numel(result_shape);
+//     std::vector<float> result_data(result_size);
 
-    /* iterate over result data and perform division */
-    for (size_t i = 0; i < result_size; ++i) {
+//     /* iterate over result data and perform division */
+//     for (size_t i = 0; i < result_size; ++i) {
 
-        /* compute the multi-dimensional index in the result shape */
-        std::vector<size_t> multi_index = unravel_index(i, result_shape);
+//         /* compute the multi-dimensional index in the result shape */
+//         std::vector<size_t> multi_index = unravel_index(i, result_shape);
 
-        /* map to indices in the original tensors */
-        size_t index_a = ravel_index(multi_index, this->shape);
-        size_t index_b = ravel_index(multi_index, other.shape);
+//         /* map to indices in the original tensors */
+//         size_t index_a = ravel_index(multi_index, this->shape);
+//         size_t index_b = ravel_index(multi_index, other.shape);
 
-        /* Perform the division */
-        result_data[i] = this->data[index_a] / other.data[index_b];
-    }
+//         /* Perform the division */
+//         result_data[i] = this->data[index_a] / other.data[index_b];
+//     }
 
-    /* allocate result tensor */
-    std::shared_ptr<Tensor> result = std::make_shared<Tensor>(result_data, result_shape, requires_grad || other.requires_grad);
+//     /* allocate result tensor */
+//     std::shared_ptr<Tensor> result = std::make_shared<Tensor>(result_data, result_shape, requires_grad || other.requires_grad);
 
-    /* construct backward function */
-    if (result->requires_grad) {
-        /*
-         * copy data necessary for backward function
-         * to avoid dangling references
-         */
-        auto this_requires_grad = this->requires_grad;
-        auto other_requires_grad = other.requires_grad;
-        auto this_backward_fn = this->backward_fn;
-        auto other_backward_fn = other.backward_fn;
+//     /* construct backward function */
+//     if (result->requires_grad) {
+//         /*
+//          * copy data necessary for backward function
+//          * to avoid dangling references
+//          */
+//         auto this_requires_grad = this->requires_grad;
+//         auto other_requires_grad = other.requires_grad;
+//         auto this_backward_fn = this->backward_fn;
+//         auto other_backward_fn = other.backward_fn;
 
-        std::thread::id tid = std::this_thread::get_id();
+//         std::thread::id tid = std::this_thread::get_id();
 
-        /* add result to computation graph */
-        {
-            std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
-            if (this_requires_grad) {
-                auto parent = std::make_shared<Tensor>(*this);
-                /* should be the same tensor in the computation graph */
-                parent->id = this->id;   
-                result->parents[tid].insert(parent);
-            }
-        }
-        {
-            std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
-            if (other_requires_grad) {
-                auto parent = std::make_shared<Tensor>(other);
-                /* should be the same tensor in the computation graph */
-                parent->id = other.id;
-                result->parents[tid].insert(parent);
-            }
-        }
+//         /* add result to computation graph */
+//         {
+//             std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
+//             if (this_requires_grad) {
+//                 auto parent = std::make_shared<Tensor>(*this);
+//                 /* should be the same tensor in the computation graph */
+//                 parent->id = this->id;   
+//                 result->parents[tid].insert(parent);
+//             }
+//         }
+//         {
+//             std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
+//             if (other_requires_grad) {
+//                 auto parent = std::make_shared<Tensor>(other);
+//                 /* should be the same tensor in the computation graph */
+//                 parent->id = other.id;
+//                 result->parents[tid].insert(parent);
+//             }
+//         }
 
-        /* Ensure thread-local gradients are initialized */
-        std::shared_ptr<Tensor> this_grad, other_grad;
-        {
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-            if (this_requires_grad) {
-                if (!this->thread_gradients[tid]) {
-                    this->thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(this->data.size(), 0.0f), this->shape, false);
-                }
-                this_grad = this->thread_gradients[tid];
-            }
-        }
-        {
-            std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-            if (other_requires_grad) {
-                if (!other.thread_gradients[tid]) {
-                    other.thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(other.data.size(), 0.0f), other.shape, false);
-                }
-                other_grad = other.thread_gradients[tid];
-            }
-        }
+//         /* Ensure thread-local gradients are initialized */
+//         std::shared_ptr<Tensor> this_grad, other_grad;
+//         {
+//             std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+//             if (this_requires_grad) {
+//                 if (!this->thread_gradients[tid]) {
+//                     this->thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(this->data.size(), 0.0f), this->shape, false);
+//                 }
+//                 this_grad = this->thread_gradients[tid];
+//             }
+//         }
+//         {
+//             std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
+//             if (other_requires_grad) {
+//                 if (!other.thread_gradients[tid]) {
+//                     other.thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(other.data.size(), 0.0f), other.shape, false);
+//                 }
+//                 other_grad = other.thread_gradients[tid];
+//             }
+//         }
 
-        result->backward_fn = [this_requires_grad, other_requires_grad,
-                    this_grad, other_grad,
-                    this_backward_fn, other_backward_fn,
-                    result, 
-                    this_data = this->data,
-                    other_data = other.data,
-                    this_shape = this->shape,
-                    other_shape = other.shape,
-                    result_shape = result->shape]() 
-        {
+//         result->backward_fn = [this_requires_grad, other_requires_grad,
+//                     this_grad, other_grad,
+//                     this_backward_fn, other_backward_fn,
+//                     result, 
+//                     this_data = this->data,
+//                     other_data = other.data,
+//                     this_shape = this->shape,
+//                     other_shape = other.shape,
+//                     result_shape = result->shape]() 
+//         {
 
-            std::thread::id tid = std::this_thread::get_id();
+//             std::thread::id tid = std::this_thread::get_id();
 
-            /* 1) Gradient w.r.t. x (this->data) */
-            if (this_requires_grad && this_grad)
-            {
-                /* temporary helper varibale to element wise gradient */
-                std::vector<float> partial_grad_x(result->thread_gradients[tid]->data.size(), 0.0f);
+//             /* 1) Gradient w.r.t. x (this->data) */
+//             if (this_requires_grad && this_grad)
+//             {
+//                 /* temporary helper varibale to element wise gradient */
+//                 std::vector<float> partial_grad_x(result->thread_gradients[tid]->data.size(), 0.0f);
 
-                /* iterate over result data and compute gradient */
-                for (size_t i = 0; i < result->thread_gradients[tid]->data.size(); ++i) {
-                    /* compute the multi-dimensional index in the result shape */
-                    std::vector<size_t> multi_index = unravel_index(i, result_shape); 
-                    /* map index into other->data */
-                    size_t index_b = ravel_index(multi_index, other_shape);
-                    /* compute the gradient */
-                    partial_grad_x[i] = result->thread_gradients[tid]->data[i] / other_data[index_b];
-                }
+//                 /* iterate over result data and compute gradient */
+//                 for (size_t i = 0; i < result->thread_gradients[tid]->data.size(); ++i) {
+//                     /* compute the multi-dimensional index in the result shape */
+//                     std::vector<size_t> multi_index = unravel_index(i, result_shape); 
+//                     /* map index into other->data */
+//                     size_t index_b = ravel_index(multi_index, other_shape);
+//                     /* compute the gradient */
+//                     partial_grad_x[i] = result->thread_gradients[tid]->data[i] / other_data[index_b];
+//                 }
 
-                /* reduce the gradient by summing over broadcasted dimension */
-                auto reduced_grad_x = reduce_grad(partial_grad_x, result_shape, this_shape);
+//                 /* reduce the gradient by summing over broadcasted dimension */
+//                 auto reduced_grad_x = reduce_grad(partial_grad_x, result_shape, this_shape);
                 
-                for (size_t i = 0; i < reduced_grad_x.size(); ++i) {
-                    this_grad->data[i] += reduced_grad_x[i];
-                }
-            } 
+//                 for (size_t i = 0; i < reduced_grad_x.size(); ++i) {
+//                     this_grad->data[i] += reduced_grad_x[i];
+//                 }
+//             } 
 
-            /* 2) Gradient w.r.t. y (other->data) */
-            if (other_requires_grad && other_grad) {
-                /* temporary helper varibale to element wise gradient */
-                std::vector<float> partial_grad_y(result->thread_gradients[tid]->data.size(), 0.0f);
+//             /* 2) Gradient w.r.t. y (other->data) */
+//             if (other_requires_grad && other_grad) {
+//                 /* temporary helper varibale to element wise gradient */
+//                 std::vector<float> partial_grad_y(result->thread_gradients[tid]->data.size(), 0.0f);
 
-                /* iterate over result data and compute gradient */
-                for (size_t i = 0; i < result->thread_gradients[tid]->data.size(); i++) {
-                    /* compute the multi-dimensional index in the result shape */
-                    std::vector<size_t> multi_index = unravel_index(i, result_shape);
-                    /* map index into data */
-                    size_t index_a = ravel_index(multi_index, this_shape);
-                    size_t index_b = ravel_index(multi_index, other_shape);
-                    /* compute the gradient */
-                    partial_grad_y[i] = -result->thread_gradients[tid]->data[i] * this_data[index_a] / (other_data[index_b] * other_data[index_b]);
-                }
+//                 /* iterate over result data and compute gradient */
+//                 for (size_t i = 0; i < result->thread_gradients[tid]->data.size(); i++) {
+//                     /* compute the multi-dimensional index in the result shape */
+//                     std::vector<size_t> multi_index = unravel_index(i, result_shape);
+//                     /* map index into data */
+//                     size_t index_a = ravel_index(multi_index, this_shape);
+//                     size_t index_b = ravel_index(multi_index, other_shape);
+//                     /* compute the gradient */
+//                     partial_grad_y[i] = -result->thread_gradients[tid]->data[i] * this_data[index_a] / (other_data[index_b] * other_data[index_b]);
+//                 }
 
-                /* reduce the gradient by summing over broadcasted dimension */
-                auto reduced_grad_y = reduce_grad(partial_grad_y, result_shape, other_shape);
+//                 /* reduce the gradient by summing over broadcasted dimension */
+//                 auto reduced_grad_y = reduce_grad(partial_grad_y, result_shape, other_shape);
                 
-                for (size_t i = 0; i < reduced_grad_y.size(); ++i) {
-                    other_grad->data[i] += reduced_grad_y[i];
-                }
-            }
-        };
-    }
+//                 for (size_t i = 0; i < reduced_grad_y.size(); ++i) {
+//                     other_grad->data[i] += reduced_grad_y[i];
+//                 }
+//             }
+//         };
+//     }
 
-    return *result;
-}
+//     return *result;
+// }
 
-/*
- * Overloaded * operator, for multiplying scalar and tensor
- */
-Tensor Tensor::operator/(const float other) const {
-    return *this / Tensor({other}, false);
-}
+// /*
+//  * Overloaded * operator, for multiplying scalar and tensor
+//  */
+// Tensor Tensor::operator/(const float other) const {
+//     return *this / Tensor({other}, false);
+// }
 
 /* 
  * Helper function to the << operator
  */
 void Tensor::print_recursive(std::ostream& os, size_t dim, size_t offset, size_t stride) const {
     os << "[";
-    for (size_t i = 0; i < shape[dim]; ++i) {
-        if (dim == shape.size() - 1) { 
+    for (size_t i = 0; i < ptr->shape[dim]; ++i) {
+        if (dim == ptr->shape.size() - 1) { 
             /* last dimension, print values directly */
-            os << data[offset + i];
+            os << ptr->data[offset + i];
         } else {
             /* recursively print nested dimensions */
-            print_recursive(os, dim + 1, offset + i * stride, stride / shape[dim + 1]);
+            print_recursive(os, dim + 1, offset + i * stride, stride / ptr->shape[dim + 1]);
         }
-        if (i + 1 < shape[dim]) os << ", ";
+        if (i + 1 < ptr->shape[dim]) os << ", ";
     }
     os << "]";
 }
@@ -556,12 +553,12 @@ void Tensor::print_recursive(std::ostream& os, size_t dim, size_t offset, size_t
  */
 std::ostream& operator<<(std::ostream& os, const Tensor& tensor) {
     os << "Tensor(";
-    tensor.print_recursive(os, 0, 0, tensor.data.size() / tensor.shape[0]);
+    tensor.print_recursive(os, 0, 0, tensor.ptr->data.size() / tensor.ptr->shape[0]);
     os << ", shape=";
     os << "[";
-    for (size_t i = 0; i < tensor.shape.size(); ++i) {
-        os << tensor.shape[i];
-        if (i + 1 < tensor.shape.size()) os << ", ";
+    for (size_t i = 0; i < tensor.ptr->shape.size(); ++i) {
+        os << tensor.ptr->shape[i];
+        if (i + 1 < tensor.ptr->shape.size()) os << ", ";
     }
     os << "]";
     os << ")";

--- a/grad/operator_overloads.cpp
+++ b/grad/operator_overloads.cpp
@@ -84,15 +84,14 @@ Tensor Tensor::operator+(const Tensor& other) const{
         }
 
         /* Capture shared pointers to gradients in backward function */
-        result.ptr->backward_fn = [this_ptr = this->ptr, other_ptr = other.ptr, result_ptr = result.ptr]() 
+        result.ptr->backward_fn = [this_ptr = this->ptr, other_ptr = other.ptr, result_ptr = result.ptr, result_shape = result.ptr->shape]() 
         {
             std::thread::id tid = std::this_thread::get_id();
-            std::cout << "Backward function for addition\n";
 
             /* 1) Gradient w.r.t. x (this->data) */
             auto this_grad = this_ptr->thread_gradients[tid];
             if (this_ptr->requires_grad && this_grad) {
-                auto reduced_grad = reduce_grad(result_ptr->thread_gradients[tid]->data, result_ptr->shape, this_ptr->shape);
+                auto reduced_grad = reduce_grad(result_ptr->thread_gradients[tid]->data, result_shape, this_ptr->shape);
                 for (size_t i = 0; i < reduced_grad.size(); ++i) {
                     this_grad->data[i] += reduced_grad[i];
                 }
@@ -101,7 +100,7 @@ Tensor Tensor::operator+(const Tensor& other) const{
             /* 2) Gradient w.r.t. y (other->data) */
             auto other_grad = other_ptr->thread_gradients[tid];
             if (other_ptr->requires_grad && other_grad) {
-                auto reduced_grad = reduce_grad(result_ptr->thread_gradients[tid]->data, result_ptr->shape, other_ptr->shape);
+                auto reduced_grad = reduce_grad(result_ptr->thread_gradients[tid]->data, result_shape, other_ptr->shape);
                 for (size_t i = 0; i < reduced_grad.size(); ++i) {
                     other_grad->data[i] += reduced_grad[i];
                 }
@@ -119,83 +118,89 @@ Tensor Tensor::operator+(const float other) const{
     return *this + Tensor({other}, false);
 }
 
-// /* 
-//  * Overloaded unary - operator
-//  * 1. Negate the data
-//  * 2. Negate the gradient if necessary
-//  * 3. Construct the result tensor
-//  * 4. If necessary, set up the backward function
-//  */
-// Tensor Tensor::operator-() const{
+/* 
+ * Overloaded unary - operator
+ * 1. Negate the data
+ * 2. Negate the gradient if necessary
+ * 3. Construct the result tensor
+ * 4. If necessary, set up the backward function
+ */
+Tensor Tensor::operator-() const{
     
-//     /* negate data */
-//     std::vector<float> result_data(data.size());
-//     for (size_t i = 0; i < data.size(); i++) {
-//         result_data[i] = -data[i];
-//     }
-    
-//     /* construct result tensor */
-//     std::shared_ptr<Tensor> result = std::make_shared<Tensor>(result_data, shape, requires_grad);
+    auto this_shape = this->ptr->shape;
 
-//     /* construct backward function */
-//     if (result->requires_grad) {
+    auto this_data = this->ptr->data;
+
+    auto this_requires_grad = this->ptr->requires_grad;
+    auto result_requires_grad = this_requires_grad;   
+
+    /* negate data */
+    std::vector<float> result_data(this_data.size());
+    for (size_t i = 0; i < this_data.size(); i++) {
+        result_data[i] = -this_data[i];
+    }
+    
+    /* construct result tensor */
+    Tensor result = Tensor(result_data, this_shape, result_requires_grad);
+
+    /* construct backward function */
+    if (result_requires_grad) {
         
-//         /*
-//          * copy data necessary for backward function
-//          * to avoid dangling references
-//          */
-//         auto sz = data.size();
-//         auto this_requires_grad = this->requires_grad;
-//         /* Store parent in a thread-safe manner */
-//         std::thread::id tid = std::this_thread::get_id();
-//         {
-//             std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
-//             if (this_requires_grad) result->parents[tid].insert(std::make_shared<Tensor>(*this));
-//         }
-//         /* Ensure thread-local gradients are initialized */
-//         std::shared_ptr<Tensor> this_grad;
-//         {
-//             std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-//             if (this_requires_grad) {
-//                 if (!this->thread_gradients[tid]) {
-//                     this->thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(this->data.size(), 0.0f), this->shape, false);
-//                 }
-//                 this_grad = this->thread_gradients[tid];
-//             }
-//         }
+        /* add result to computation graph */
+        std::thread::id tid = std::this_thread::get_id();
+        {
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_PARENTS_MUTEX);
+            if (this_requires_grad) {
+                result.ptr->parents[tid].insert(this->ptr);
+            }
+        }
+        /* Ensure thread-local gradients are initialized */
+        std::shared_ptr<TensorData> this_grad;
+        {
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_GRAD_MUTEX);
+            if (this_requires_grad) {
+                if (!this->ptr->thread_gradients[tid]) {
+                    this->ptr->thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(this_data.size(), 0.0f), this_shape, false);
+                }
+                this_grad = this->ptr->thread_gradients[tid];
+            }
+        }
 
-//         result->backward_fn = [sz,
-//                               this_requires_grad, this_grad,
-//                               result]() {
-//             std::thread::id tid = std::this_thread::get_id();
+        result.ptr->backward_fn = [this_ptr = this->ptr, result_ptr = result.ptr]() 
+     {
+            std::thread::id tid = std::this_thread::get_id();
 
-//             if (this_requires_grad && this_grad) {
+            auto this_data = this_ptr->data;
+            auto this_grad = this_ptr->thread_gradients[tid];
 
-//                 for (size_t i = 0; i < sz; i++) {
-//                     this_grad->data[i] -= result->thread_gradients[tid]->data[i];
-//                 }
-//             }
-//         };
-//     }
+            auto result_grad = result_ptr->thread_gradients[tid]->data;
+            if (this_ptr->requires_grad && this_grad) {
 
-//     return *result;
-// }
+                for (size_t i = 0; i < this_data.size(); i++) {
+                    this_grad->data[i] -= result_grad[i];
+                }
+            }
+        };
+    }
 
-// /* 
-//  * Overloaded binary - operator
-//  * using unary - and + operators
-//  * this - other = this + (-other)
-//  */
-// Tensor Tensor::operator-(const Tensor& other) const{
-//     /* a - b =  a + (-b) */
-//     return *this + (-other);
-// }
-// /*
-//  * Overloaded - operator, for subtracting scalar and tensor
-//  */
-// Tensor Tensor::operator-(const float other) const{
-//     return *this - Tensor({other}, false);
-// }
+    return result;
+}
+
+/* 
+ * Overloaded binary - operator
+ * using unary - and + operators
+ * this - other = this + (-other)
+ */
+Tensor Tensor::operator-(const Tensor& other) const{
+    /* a - b =  a + (-b) */
+    return *this + (-other);
+}
+/*
+ * Overloaded - operator, for subtracting scalar and tensor
+ */
+Tensor Tensor::operator-(const float other) const{
+    return *this - Tensor({other}, false);
+}
 
 /* 
  * Overloaded * operator, does support broadcasting
@@ -362,172 +367,172 @@ Tensor Tensor::operator*(const float other) const {
     return *this * Tensor({other}, false);
 }
 
-// /* 
-//  * Overloaded / operator, does support broadcasting
-//  * 1. Check if tensors are broadcastable
-//  * 2. iterate over result data
-//  * 3. construct multi-dimensional index
-//  * 4. perform division
-//  * 4. If necessary, set up the backward function
-//  */
-// Tensor Tensor::operator/(const Tensor& other) const {
+/* 
+ * Overloaded / operator, does support broadcasting
+ * 1. Check if tensors are broadcastable
+ * 2. iterate over result data
+ * 3. construct multi-dimensional index
+ * 4. perform division
+ * 4. If necessary, set up the backward function
+ */
+Tensor Tensor::operator/(const Tensor& other) const {
+ 
+    auto this_shape = this->ptr->shape;
+    auto other_shape = other.ptr->shape;
+
+    auto this_data = this->ptr->data;
+    auto other_data = other.ptr->data;
+
+    auto this_requires_grad = this->ptr->requires_grad;
+    auto other_requires_grad = other.ptr->requires_grad;
+    auto result_requires_grad = this_requires_grad || other_requires_grad;   
+   
+    /* infer result shape */
+    std::vector<size_t> result_shape;
+    result_shape = broadcast(this_shape, other_shape);
     
-//     /* infer result shape */
-//     std::vector<size_t> result_shape;
-//     result_shape = broadcast(this->shape, other.shape);
-    
-//     if (result_shape.empty()) {
-//         printShapes(this->shape, other.shape);
-//         throw std::invalid_argument("Tensor shapes must be broadcastable for division.");
-//     }
+    if (result_shape.empty()) {
+        printShapes(this_shape, other_shape);
+        throw std::invalid_argument("Tensor shapes must be broadcastable for division.");
+    }
             
-//     /* allocate memory for result data */
-//     size_t result_size = numel(result_shape);
-//     std::vector<float> result_data(result_size);
+    /* allocate memory for result data */
+    size_t result_size = numel(result_shape);
+    std::vector<float> result_data(result_size);
 
-//     /* iterate over result data and perform division */
-//     for (size_t i = 0; i < result_size; ++i) {
+    /* iterate over result data and perform division */
+    for (size_t i = 0; i < result_size; ++i) {
 
-//         /* compute the multi-dimensional index in the result shape */
-//         std::vector<size_t> multi_index = unravel_index(i, result_shape);
+        /* compute the multi-dimensional index in the result shape */
+        std::vector<size_t> multi_index = unravel_index(i, result_shape);
 
-//         /* map to indices in the original tensors */
-//         size_t index_a = ravel_index(multi_index, this->shape);
-//         size_t index_b = ravel_index(multi_index, other.shape);
+        /* map to indices in the original tensors */
+        size_t index_a = ravel_index(multi_index, this_shape);
+        size_t index_b = ravel_index(multi_index, other_shape);
 
-//         /* Perform the division */
-//         result_data[i] = this->data[index_a] / other.data[index_b];
-//     }
+        /* Perform the division */
+        result_data[i] = this_data[index_a] / other_data[index_b];
+    }
 
-//     /* allocate result tensor */
-//     std::shared_ptr<Tensor> result = std::make_shared<Tensor>(result_data, result_shape, requires_grad || other.requires_grad);
+    /* allocate result tensor */
+    Tensor result = Tensor(result_data, result_shape, result_requires_grad);
 
-//     /* construct backward function */
-//     if (result->requires_grad) {
-//         /*
-//          * copy data necessary for backward function
-//          * to avoid dangling references
-//          */
-//         auto this_requires_grad = this->requires_grad;
-//         auto other_requires_grad = other.requires_grad;
-//         auto this_backward_fn = this->backward_fn;
-//         auto other_backward_fn = other.backward_fn;
+    /* construct backward function */
+    if (result_requires_grad) {
 
-//         std::thread::id tid = std::this_thread::get_id();
+        std::thread::id tid = std::this_thread::get_id();
 
-//         /* add result to computation graph */
-//         {
-//             std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
-//             if (this_requires_grad) {
-//                 auto parent = std::make_shared<Tensor>(*this);
-//                 /* should be the same tensor in the computation graph */
-//                 parent->id = this->id;   
-//                 result->parents[tid].insert(parent);
-//             }
-//         }
-//         {
-//             std::lock_guard<std::mutex> lock(GLOBAL_PARENTS_MUTEX);
-//             if (other_requires_grad) {
-//                 auto parent = std::make_shared<Tensor>(other);
-//                 /* should be the same tensor in the computation graph */
-//                 parent->id = other.id;
-//                 result->parents[tid].insert(parent);
-//             }
-//         }
+        /* add result to computation graph */
+        {
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_PARENTS_MUTEX);
+            if (this_requires_grad) {
+                result.ptr->parents[tid].insert(this->ptr);
+            }
+        }
+        {
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_PARENTS_MUTEX);
+            if (other_requires_grad) {
+                result.ptr->parents[tid].insert(other.ptr);
+            }
+        }
 
-//         /* Ensure thread-local gradients are initialized */
-//         std::shared_ptr<Tensor> this_grad, other_grad;
-//         {
-//             std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-//             if (this_requires_grad) {
-//                 if (!this->thread_gradients[tid]) {
-//                     this->thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(this->data.size(), 0.0f), this->shape, false);
-//                 }
-//                 this_grad = this->thread_gradients[tid];
-//             }
-//         }
-//         {
-//             std::lock_guard<std::mutex> lock(GLOBAL_GRAD_MUTEX);
-//             if (other_requires_grad) {
-//                 if (!other.thread_gradients[tid]) {
-//                     other.thread_gradients[tid] = std::make_shared<Tensor>(std::vector<float>(other.data.size(), 0.0f), other.shape, false);
-//                 }
-//                 other_grad = other.thread_gradients[tid];
-//             }
-//         }
+        /* Ensure thread-local gradients are initialized */
+        std::shared_ptr<TensorData> this_grad, other_grad;
+        {
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_GRAD_MUTEX);
+            if (this_requires_grad) {
+                if (!this->ptr->thread_gradients[tid]) {
+                    this->ptr->thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(this->ptr->data.size(), 0.0f), this_shape, false);
+                }
+                this_grad = this->ptr->thread_gradients[tid];
+            }
+        }
+        {
+            std::lock_guard<std::mutex> lock(TensorData::GLOBAL_GRAD_MUTEX);
+            if (other_requires_grad) {
+                if (!other.ptr->thread_gradients[tid]) {
+                    other.ptr->thread_gradients[tid] = std::make_shared<TensorData>(std::vector<float>(other.ptr->data.size(), 0.0f), other_shape, false);
+                }
+                other_grad = other.ptr->thread_gradients[tid];
+            }
+        }
 
-//         result->backward_fn = [this_requires_grad, other_requires_grad,
-//                     this_grad, other_grad,
-//                     this_backward_fn, other_backward_fn,
-//                     result, 
-//                     this_data = this->data,
-//                     other_data = other.data,
-//                     this_shape = this->shape,
-//                     other_shape = other.shape,
-//                     result_shape = result->shape]() 
-//         {
+        result.ptr->backward_fn = [this_ptr = this->ptr, other_ptr = other.ptr, result_ptr = result.ptr]() 
+        {
 
-//             std::thread::id tid = std::this_thread::get_id();
+            std::thread::id tid = std::this_thread::get_id();
 
-//             /* 1) Gradient w.r.t. x (this->data) */
-//             if (this_requires_grad && this_grad)
-//             {
-//                 /* temporary helper varibale to element wise gradient */
-//                 std::vector<float> partial_grad_x(result->thread_gradients[tid]->data.size(), 0.0f);
+            auto this_shape = this_ptr->shape;
+            auto other_shape = other_ptr->shape;
 
-//                 /* iterate over result data and compute gradient */
-//                 for (size_t i = 0; i < result->thread_gradients[tid]->data.size(); ++i) {
-//                     /* compute the multi-dimensional index in the result shape */
-//                     std::vector<size_t> multi_index = unravel_index(i, result_shape); 
-//                     /* map index into other->data */
-//                     size_t index_b = ravel_index(multi_index, other_shape);
-//                     /* compute the gradient */
-//                     partial_grad_x[i] = result->thread_gradients[tid]->data[i] / other_data[index_b];
-//                 }
+            auto this_data = this_ptr->data;
+            auto other_data = other_ptr->data;
 
-//                 /* reduce the gradient by summing over broadcasted dimension */
-//                 auto reduced_grad_x = reduce_grad(partial_grad_x, result_shape, this_shape);
+            auto result_shape = result_ptr->shape;
+            auto result_data = result_ptr->data;
+            auto result_grad = result_ptr->thread_gradients[tid]->data;
+
+            auto this_grad = this_ptr->thread_gradients[tid];
+            auto other_grad = other_ptr->thread_gradients[tid];
+            /* 1) Gradient w.r.t. x (this->data) */
+            if (this_ptr->requires_grad && this_grad)
+            {
+                /* temporary helper varibale to element wise gradient */
+                std::vector<float> partial_grad_x(result_grad.size(), 0.0f);
+
+                /* iterate over result data and compute gradient */
+                for (size_t i = 0; i < result_grad.size(); ++i) {
+                    /* compute the multi-dimensional index in the result shape */
+                    std::vector<size_t> multi_index = unravel_index(i, result_shape); 
+                    /* map index into other->data */
+                    size_t index_b = ravel_index(multi_index, other_shape);
+                    /* compute the gradient */
+                    partial_grad_x[i] = result_grad[i] / other_data[index_b];
+                }
+
+                /* reduce the gradient by summing over broadcasted dimension */
+                auto reduced_grad_x = reduce_grad(partial_grad_x, result_shape, this_shape);
                 
-//                 for (size_t i = 0; i < reduced_grad_x.size(); ++i) {
-//                     this_grad->data[i] += reduced_grad_x[i];
-//                 }
-//             } 
+                for (size_t i = 0; i < reduced_grad_x.size(); ++i) {
+                    this_grad->data[i] += reduced_grad_x[i];
+                }
+            } 
 
-//             /* 2) Gradient w.r.t. y (other->data) */
-//             if (other_requires_grad && other_grad) {
-//                 /* temporary helper varibale to element wise gradient */
-//                 std::vector<float> partial_grad_y(result->thread_gradients[tid]->data.size(), 0.0f);
+            /* 2) Gradient w.r.t. y (other->data) */
+            if (other_ptr->requires_grad && other_grad) {
+                /* temporary helper varibale to element wise gradient */
+                std::vector<float> partial_grad_y(result_grad.size(), 0.0f);
 
-//                 /* iterate over result data and compute gradient */
-//                 for (size_t i = 0; i < result->thread_gradients[tid]->data.size(); i++) {
-//                     /* compute the multi-dimensional index in the result shape */
-//                     std::vector<size_t> multi_index = unravel_index(i, result_shape);
-//                     /* map index into data */
-//                     size_t index_a = ravel_index(multi_index, this_shape);
-//                     size_t index_b = ravel_index(multi_index, other_shape);
-//                     /* compute the gradient */
-//                     partial_grad_y[i] = -result->thread_gradients[tid]->data[i] * this_data[index_a] / (other_data[index_b] * other_data[index_b]);
-//                 }
+                /* iterate over result data and compute gradient */
+                for (size_t i = 0; i < result_grad.size(); i++) {
+                    /* compute the multi-dimensional index in the result shape */
+                    std::vector<size_t> multi_index = unravel_index(i, result_shape);
+                    /* map index into data */
+                    size_t index_a = ravel_index(multi_index, this_shape);
+                    size_t index_b = ravel_index(multi_index, other_shape);
+                    /* compute the gradient */
+                    partial_grad_y[i] = -result_grad[i] * this_data[index_a] / (other_data[index_b] * other_data[index_b]);
+                }
 
-//                 /* reduce the gradient by summing over broadcasted dimension */
-//                 auto reduced_grad_y = reduce_grad(partial_grad_y, result_shape, other_shape);
+                /* reduce the gradient by summing over broadcasted dimension */
+                auto reduced_grad_y = reduce_grad(partial_grad_y, result_shape, other_shape);
                 
-//                 for (size_t i = 0; i < reduced_grad_y.size(); ++i) {
-//                     other_grad->data[i] += reduced_grad_y[i];
-//                 }
-//             }
-//         };
-//     }
+                for (size_t i = 0; i < reduced_grad_y.size(); ++i) {
+                    other_grad->data[i] += reduced_grad_y[i];
+                }
+            }
+        };
+    }
 
-//     return *result;
-// }
+    return result;
+}
 
-// /*
-//  * Overloaded * operator, for multiplying scalar and tensor
-//  */
-// Tensor Tensor::operator/(const float other) const {
-//     return *this / Tensor({other}, false);
-// }
+/*
+ * Overloaded * operator, for multiplying scalar and tensor
+ */
+Tensor Tensor::operator/(const float other) const {
+    return *this / Tensor({other}, false);
+}
 
 /* 
  * Helper function to the << operator

--- a/grad/util.cpp
+++ b/grad/util.cpp
@@ -2,8 +2,8 @@
 std::atomic<std::uint64_t> id_counter = 1;
 std::mt19937 global_generator(42);
 
-std::mutex Tensor::GLOBAL_GRAD_MUTEX;
-std::mutex Tensor::GLOBAL_PARENTS_MUTEX;
+std::mutex TensorData::GLOBAL_GRAD_MUTEX;
+std::mutex TensorData::GLOBAL_PARENTS_MUTEX;
 
 /* helper function to get tensor id*/
 size_t get_id() {
@@ -22,13 +22,13 @@ void set_seed(int seed) {
 /* helper function zeroing out the gradient */
 void Tensor::zero_grad() {
     std::thread::id tid = std::this_thread::get_id();
-    if (thread_gradients[tid]) {
-        std::fill(thread_gradients[tid]->data.begin(), thread_gradients[tid]->data.end(), 0.0f);
+    if (ptr->thread_gradients[tid]) {
+        std::fill(ptr->thread_gradients[tid]->data.begin(), ptr->thread_gradients[tid]->data.end(), 0.0f);
     }
 }
 
 /* helper function to count the number of elements */
-size_t Tensor::numel(const std::vector<size_t>& shp) {
+size_t numel(const std::vector<size_t>& shp) {
     size_t product = 1;
     for (auto s : shp) {
         product *= s;
@@ -38,7 +38,7 @@ size_t Tensor::numel(const std::vector<size_t>& shp) {
 
 /* helper function to print the shape of a tensor */
 void Tensor::print_shape() const{
-    for (size_t s : shape) {
+    for (size_t s : ptr->shape) {
         std::cout << s << " ";
     }
     std::cout << std::endl;
@@ -131,7 +131,7 @@ std::vector<size_t> unravel_index(size_t idx, const std::vector<size_t>& shape) 
 std::vector<float> reduce_grad(const std::vector<float>& grad, 
                                const std::vector<size_t>& grad_shape, 
                                const std::vector<size_t>& original_shape) {
-    std::vector<float> reduced_grad(Tensor::numel(original_shape), 0.0f);
+    std::vector<float> reduced_grad(numel(original_shape), 0.0f);
 
     for (size_t i = 0; i < grad.size(); ++i) {
         std::vector<size_t> multi_index = unravel_index(i, grad_shape);
@@ -172,21 +172,21 @@ void printShapes(const std::vector<size_t>& shape1, const std::vector<size_t>& s
  */
 Tensor Tensor::grad() const{
     std::thread::id tid = std::this_thread::get_id();
-    if (!thread_gradients[tid]) {
+    if (!ptr->thread_gradients[tid]) {
         throw std::runtime_error("Tensor has no gradient.");
     }
-    return *(thread_gradients[tid].get());
+    return Tensor(ptr->thread_gradients[tid]);
 }
 
 /* 
  * disable gradient computation
  */
 void Tensor::eval() {
-    requires_grad = false;
+    ptr->requires_grad = false;
 }
 /*
  * enable gradient computation
  */
 void Tensor::train() {
-    requires_grad = true;
+    ptr->requires_grad = true;
 }

--- a/grad/util.cpp
+++ b/grad/util.cpp
@@ -168,6 +168,26 @@ void printShapes(const std::vector<size_t>& shape1, const std::vector<size_t>& s
 }
 
 /*
+ * helper function returning the shape of a tensor 
+ */
+std::vector<size_t> Tensor::shape() const {
+    if(this->ptr == NULL){
+        return {};
+    }
+    return ptr->shape;
+}
+
+/*
+ * helper function returning the data of a tensor 
+ */
+std::vector<float> Tensor::data() const {
+    if(this->ptr == NULL){
+        return {};
+    }
+    return ptr->data;
+};
+
+/*
  * helper function returning the gradient tensor
  */
 Tensor Tensor::grad() const{

--- a/tests/test_functions/multidim_test.cpp
+++ b/tests/test_functions/multidim_test.cpp
@@ -15,15 +15,15 @@ void multidim_test(const std::string& test_name,
     std::vector<int64_t> shape1_int(shape1.begin(), shape1.end());
     std::vector<int64_t> shape2_int(shape2.begin(), shape2.end());
 
-    auto a_torch = torch::from_blob(a_cpp.data.data(), shape1_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
-    auto b_torch = torch::from_blob(b_cpp.data.data(), shape2_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
+    auto a_torch = torch::from_blob(a_cpp.data().data(), shape1_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
+    auto b_torch = torch::from_blob(b_cpp.data().data(), shape2_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
 
     auto c_torch = torch_op(a_torch, b_torch);
     c_torch.backward();
     
-    ASSERT_TRUE(compare_tensors(c_cpp.data, c_torch, test_name + " Result"));
-    ASSERT_TRUE(compare_tensors(a_cpp.grad().data, a_torch.grad(), test_name + " Gradient (a)"));
-    ASSERT_TRUE(compare_tensors(b_cpp.grad().data, b_torch.grad(), test_name + " Gradient (b)"));
+    ASSERT_TRUE(compare_tensors(c_cpp.data(), c_torch, test_name + " Result"));
+    ASSERT_TRUE(compare_tensors(a_cpp.grad().data(), a_torch.grad(), test_name + " Gradient (a)"));
+    ASSERT_TRUE(compare_tensors(b_cpp.grad().data(), b_torch.grad(), test_name + " Gradient (b)"));
 }
 
 void multidim_test(const std::string& test_name,
@@ -44,15 +44,15 @@ void multidim_test(const std::string& test_name,
     std::vector<int64_t> shape2_int(shape2.begin(), shape2.end());
     std::vector<int64_t> shape3_int(shape3.begin(), shape3.end());
 
-    auto a_torch = torch::from_blob(a_cpp.data.data(), shape1_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
-    auto b_torch = torch::from_blob(b_cpp.data.data(), shape2_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
-    auto c_torch = torch::from_blob(c_cpp.data.data(), shape3_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
+    auto a_torch = torch::from_blob(a_cpp.data().data(), shape1_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
+    auto b_torch = torch::from_blob(b_cpp.data().data(), shape2_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
+    auto c_torch = torch::from_blob(c_cpp.data().data(), shape3_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
 
     auto d_torch = torch_op(a_torch, b_torch, c_torch);
     d_torch.backward();
     
-    ASSERT_TRUE(compare_tensors(d_cpp.data, d_torch, test_name + " Result"));
-    ASSERT_TRUE(compare_tensors(a_cpp.grad().data, a_torch.grad(), test_name + " Gradient (a)"));
-    ASSERT_TRUE(compare_tensors(b_cpp.grad().data, b_torch.grad(), test_name + " Gradient (b)"));
-    ASSERT_TRUE(compare_tensors(c_cpp.grad().data, c_torch.grad(), test_name + " Gradient (c)"));
+    ASSERT_TRUE(compare_tensors(d_cpp.data(), d_torch, test_name + " Result"));
+    ASSERT_TRUE(compare_tensors(a_cpp.grad().data(), a_torch.grad(), test_name + " Gradient (a)"));
+    ASSERT_TRUE(compare_tensors(b_cpp.grad().data(), b_torch.grad(), test_name + " Gradient (b)"));
+    ASSERT_TRUE(compare_tensors(c_cpp.grad().data(), c_torch.grad(), test_name + " Gradient (c)"));
 }

--- a/tests/test_functions/reduction_test.cpp
+++ b/tests/test_functions/reduction_test.cpp
@@ -8,13 +8,13 @@ void reduction_test(const std::string& test_name,
     Tensor c_cpp = cpp_op(a_cpp);
     c_cpp.backward();
 
-    auto a_torch = torch::tensor(a_cpp.data, torch::TensorOptions().dtype(torch::kFloat32)).requires_grad_(true);
+    auto a_torch = torch::tensor(a_cpp.data(), torch::TensorOptions().dtype(torch::kFloat32)).requires_grad_(true);
     auto c_torch = torch_op(a_torch);
     c_torch.backward();
     
     /* compare_tensors tensors needed here because we need to compare gradients as well */
-    ASSERT_TRUE(compare_tensors(c_cpp.data, c_torch, test_name + " Result"));
-    ASSERT_TRUE(compare_tensors(a_cpp.grad().data, a_torch.grad(), test_name + " Gradient (a)"));
+    ASSERT_TRUE(compare_tensors(c_cpp.data(), c_torch, test_name + " Result"));
+    ASSERT_TRUE(compare_tensors(a_cpp.grad().data(), a_torch.grad(), test_name + " Gradient (a)"));
 }
 
 void reduction_test(const std::string& test_name, 
@@ -28,11 +28,11 @@ void reduction_test(const std::string& test_name,
 
     std::vector<int64_t> shape_int(shape.begin(), shape.end());
 
-    auto a_torch = torch::from_blob(a_cpp.data.data(), shape_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
+    auto a_torch = torch::from_blob(a_cpp.data().data(), shape_int, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
     auto c_torch = torch_op(a_torch);
     c_torch.backward();
     
     /* compare_tensors tensors needed here because we need to compare gradients as well */
-    ASSERT_TRUE(compare_tensors(c_cpp.data, c_torch, test_name + " Result"));
-    ASSERT_TRUE(compare_tensors(a_cpp.grad().data, a_torch.grad(), test_name + " Gradient (a)"));
+    ASSERT_TRUE(compare_tensors(c_cpp.data(), c_torch, test_name + " Result"));
+    ASSERT_TRUE(compare_tensors(a_cpp.grad().data(), a_torch.grad(), test_name + " Gradient (a)"));
 }

--- a/tests/test_functions/scalar_test.cpp
+++ b/tests/test_functions/scalar_test.cpp
@@ -10,13 +10,13 @@ void scalar_test(const std::string& test_name,
     Tensor c_cpp = cpp_op(a_cpp, b_cpp);
     c_cpp.backward();
 
-    auto a_torch = torch::from_blob(a_cpp.data.data(), {1}, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
-    auto b_torch = torch::from_blob(b_cpp.data.data(), {1}, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
+    auto a_torch = torch::from_blob(a_cpp.data().data(), {1}, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
+    auto b_torch = torch::from_blob(b_cpp.data().data(), {1}, torch::TensorOptions().dtype(torch::kFloat32)).clone().requires_grad_(true);
 
     auto c_torch = torch_op(a_torch, b_torch);
     c_torch.backward();
     
-    ASSERT_TRUE(compare_scalars(c_cpp.data[0], c_torch.item<float>(), test_name + " Result"));
-    ASSERT_TRUE(compare_scalars(a_cpp.grad().data[0], a_torch.grad().item<float>(), test_name + " Gradient (a)"));
-    ASSERT_TRUE(compare_scalars(b_cpp.grad().data[0], b_torch.grad().item<float>(), test_name + " Gradient (b)"));
+    ASSERT_TRUE(compare_scalars(c_cpp.data()[0], c_torch.item<float>(), test_name + " Result"));
+    ASSERT_TRUE(compare_scalars(a_cpp.grad().data()[0], a_torch.grad().item<float>(), test_name + " Gradient (a)"));
+    ASSERT_TRUE(compare_scalars(b_cpp.grad().data()[0], b_torch.grad().item<float>(), test_name + " Gradient (b)"));
 }

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -16,7 +16,7 @@ bool compare_scalars(float cpp_value, float torch_value, const std::string& test
 bool compare_tensors(const std::vector<float>& cpp_data, const torch::Tensor& torch_tensor, const std::string& test_name) {
     auto torch_data = torch_tensor.flatten().data_ptr<float>();
     for (size_t i = 0; i < cpp_data.size(); ++i) {
-        if (std::abs(cpp_data[i] - torch_data[i]) > 1e-3) {
+        if (std::abs(cpp_data[i] - torch_data[i]) > 1e-4) {
             std::cerr << test_name << " FAILED at index " << i << ": " << cpp_data[i] << " (cpp) vs " << torch_data[i] << " (torch).\n";
             std::cerr << "Difference: " << std::abs(cpp_data[i] - torch_data[i]) << std::endl;
             return false;
@@ -184,9 +184,9 @@ TEST(TensorTest, ManCrossEntropyLoss) {
         {3, 42},
         [](Tensor a) { 
             Tensor y_true({32, 10, 2}, {3}, false);
-            Tensor y_pred_softmax = a.softmax(a.shape.size() - 1);
-            Tensor y_true_one_hot = y_true.onehot_encode(a.shape.back());
-            Tensor neg_log_likelihood = -(y_true_one_hot * y_pred_softmax.log()).sum(a.shape.size() - 1);
+            Tensor y_pred_softmax = a.softmax(a.shape().size() - 1);
+            Tensor y_true_one_hot = y_true.onehot_encode(a.shape().back());
+            Tensor neg_log_likelihood = -(y_true_one_hot * y_pred_softmax.log()).sum(a.shape().size() - 1);
             return neg_log_likelihood.mean();
         },
         [](torch::Tensor a) {


### PR DESCRIPTION
Fixed the following issue:
During backprob we need to store a reference to the parent tensor that will not be deallocated before the child executed its backward function.
Previously this implementation used direct shared pointers to the parent. unfortunately this means that in every backward function we needed to copy the parents and store then separately.
This excessive copying lead to a memory bottleneck, particularly obvious during execution on multiple threads.
To handle this we now directly manage the data for each tensor using shared pointers. This allows us to only copy the pointer and not the data during backpropagation. This speeds up execution on a single thread by ~ 5x and ~10x for multi-threaded execution. 